### PR TITLE
Fixing bug that every extension on a numeric type converts a input field into a slider.

### DIFF
--- a/src/assets/files/questionnaire.js
+++ b/src/assets/files/questionnaire.js
@@ -62,12 +62,10 @@ export default {
                 "extension": [{
                         "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
                         "valueCodeableConcept": {
-                            "CodeableConcept": {
                                 "coding": [{
                                     "system": "http://hl7.org/fhir/questionnaire-item-control",
                                     "code": "slider"
                                 }]
-                            }
                         }
                     },
                     {
@@ -471,7 +469,7 @@ export default {
                     "operator": "=",
                     "answerString": "lala"
                 }]
-            },
+            }
         ]
     }, {
         "linkId": "2",

--- a/src/assets/files/questionnaire.js
+++ b/src/assets/files/questionnaire.js
@@ -21,11 +21,11 @@ export default {
         "type": "group",
         "required": true,
         "item": [{
-                "linkId": "1.1",
-                "text": "Das ist eine Freitextabfrage",
-                "type": "string",
-                "required": true
-            },
+            "linkId": "1.1",
+            "text": "Das ist eine Freitextabfrage",
+            "type": "string",
+            "required": true
+        },
             {
                 "linkId": "1.2",
                 "text": "Das ist eine Datumsabfrage",
@@ -60,14 +60,14 @@ export default {
                 "text": "Das ist eine Slider-Abfrage",
                 "type": "integer",
                 "extension": [{
-                        "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                        "valueCodeableConcept": {
-                                "coding": [{
-                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                    "code": "slider"
-                                }]
-                        }
-                    },
+                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                    "valueCodeableConcept": {
+                        "coding": [{
+                            "system": "http://hl7.org/fhir/questionnaire-item-control",
+                            "code": "slider"
+                        }]
+                    }
+                },
                     {
                         "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-lowRangeLabel",
                         "valueString": "Niedrig"
@@ -103,8 +103,8 @@ export default {
                 "type": "open-choice",
                 "required": true,
                 "answerOption": [{
-                        "valueString": "Option A"
-                    },
+                    "valueString": "Option A"
+                },
                     {
                         "valueString": "Option B"
                     },
@@ -119,11 +119,11 @@ export default {
                 "type": "group",
                 "required": true,
                 "item": [{
-                        "linkId": "1.10.1",
-                        "text": "Option A",
-                        "type": "boolean",
-                        "required": true
-                    },
+                    "linkId": "1.10.1",
+                    "text": "Option A",
+                    "type": "boolean",
+                    "required": true
+                },
                     {
                         "linkId": "1.10.2",
                         "text": "Option B",
@@ -144,8 +144,8 @@ export default {
                 "type": "choice",
                 "required": true,
                 "answerOption": [{
-                        "valueString": "Option A"
-                    },
+                    "valueString": "Option A"
+                },
                     {
                         "valueString": "Option B"
                     },
@@ -203,11 +203,11 @@ export default {
                 "type": "group",
                 "required": true,
                 "item": [{
-                        "linkId": "1.15.1",
-                        "text": "Abfrage Dezimalzahl (erwartet = 1.5)",
-                        "type": "decimal",
-                        "required": true
-                    },
+                    "linkId": "1.15.1",
+                    "text": "Abfrage Dezimalzahl (erwartet = 1.5)",
+                    "type": "decimal",
+                    "required": true
+                },
                     {
                         "linkId": "1.15.2",
                         "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
@@ -227,11 +227,11 @@ export default {
                 "type": "group",
                 "required": true,
                 "item": [{
-                        "linkId": "1.16.1",
-                        "text": "Abfrage Ganzzahl (erwartet = 1)",
-                        "type": "integer",
-                        "required": true
-                    },
+                    "linkId": "1.16.1",
+                    "text": "Abfrage Ganzzahl (erwartet = 1)",
+                    "type": "integer",
+                    "required": true
+                },
                     {
                         "linkId": "1.16.2",
                         "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
@@ -251,11 +251,11 @@ export default {
                 "type": "group",
                 "required": true,
                 "item": [{
-                        "linkId": "1.17.1",
-                        "text": "Abfrage Datum (erwartet = 01.01.2021)",
-                        "type": "date",
-                        "required": true
-                    },
+                    "linkId": "1.17.1",
+                    "text": "Abfrage Datum (erwartet = 01.01.2021)",
+                    "type": "date",
+                    "required": true
+                },
                     {
                         "linkId": "1.17.2",
                         "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
@@ -469,7 +469,51 @@ export default {
                     "operator": "=",
                     "answerString": "lala"
                 }]
-            }
+            },
+            {
+                "linkId": "1.37",
+                "text": "Das ist eine Multiple-Choice-Abfrage mit Coding",
+                "type": "open-choice",
+                "required": true,
+                "answerOption": [{
+                        "valueCoding": {
+                            "system": "snomed", "code": "A", "display": "Alpha"
+                        }
+                    },
+                    {
+                        "valueCoding": {
+                            "system": "snomed", "code": "B", "display": "Beta"
+                        }
+                    },
+                    {
+                        "valueCoding": {
+                            "system": "snomed", "code": "C", "display": "Gamma"
+                        }
+                    }
+                ]
+            },
+            {
+                "linkId": "1.38",
+                "text": "Das ist eine Single-Choice-Abfrage mit Coding",
+                "type": "choice",
+                "required": true,
+                "answerOption": [{
+                        "valueCoding": {
+                            "system": "snomed", "code": "A", "display": "Alpha"
+                        }
+                    },
+                    {
+                        "valueCoding": {
+                            "system": "snomed", "code": "B", "display": "Beta"
+                        }
+                    },
+                    {
+                        "valueCoding": {
+                            "system": "snomed", "code": "C", "display": "Gamma"
+                        }
+                    }
+                ]
+            },
         ]
     }, {
         "linkId": "2",
@@ -482,37 +526,37 @@ export default {
             "type": "group",
             "required": true,
             "item": [{
-                    "linkId": "2.1.1",
-                    "text": "Untergruppe 2",
-                    "type": "group",
-                    "required": true,
-                    "item": [{
-                            "linkId": "2.1.1.1",
-                            "text": "Frage der Untergruppe 2",
+                "linkId": "2.1.1",
+                "text": "Untergruppe 2",
+                "type": "group",
+                "required": true,
+                "item": [{
+                    "linkId": "2.1.1.1",
+                    "text": "Frage der Untergruppe 2",
+                    "type": "string",
+                    "required": true
+                },
+                    {
+                        "linkId": "2.1.1.2",
+                        "text": "Untergruppe 3",
+                        "type": "group",
+                        "required": true,
+                        "item": [{
+                            "linkId": "2.1.1.2.1",
+                            "text": "Frage 1 der Untergruppe 3",
                             "type": "string",
                             "required": true
                         },
-                        {
-                            "linkId": "2.1.1.2",
-                            "text": "Untergruppe 3",
-                            "type": "group",
-                            "required": true,
-                            "item": [{
-                                    "linkId": "2.1.1.2.1",
-                                    "text": "Frage 1 der Untergruppe 3",
-                                    "type": "string",
-                                    "required": true
-                                },
-                                {
-                                    "linkId": "2.1.1.2.2",
-                                    "text": "Frage 2 der Untergruppe 3",
-                                    "type": "string",
-                                    "required": true
-                                }
-                            ]
-                        }
-                    ]
-                },
+                            {
+                                "linkId": "2.1.1.2.2",
+                                "text": "Frage 2 der Untergruppe 3",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                ]
+            },
                 {
                     "linkId": "2.1.2",
                     "text": "Frage der Untergruppe 1",

--- a/src/components/modal/questionnaireModal.js
+++ b/src/components/modal/questionnaireModal.js
@@ -652,7 +652,14 @@ class QuestionnaireModal extends Component {
 			// this also utilizes the decimal-pad or the num-pad
 			case 'integer':		
 			case 'decimal':
-				return (item.extension && item.extension.length > 0) ? this.createSlider(item) : this.createInput(item)
+				let itemControlExtension = item?.extension?.find(e => e.url === "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl");
+				if(itemControlExtension?.valueCodeableConcept?.coding?.find(c => c.system === "http://hl7.org/fhir/questionnaire-item-control" && c.code === "slider")) {
+					return this.createSlider(item);
+				} else {
+					return this.createInput(item);
+				}
+
+
 			
 			// if nothing else matches - display the title if at least the dependendcies check out
 			default:

--- a/src/components/modal/questionnaireModal.js
+++ b/src/components/modal/questionnaireModal.js
@@ -204,8 +204,12 @@ class QuestionnaireModal extends Component {
 	 * @param  {AnswerOption} item entry of an answerOption-entry.
 	 */
 	getItemTitle = item => {
+		if (item.valueCoding) {
+			return item.valueCoding.display ?? item.valueCoding.code;
+		}
+
 		// get the string
-		let title = item.valueString || (item.valueInteger ? item.valueInteger.toString() : 'NO NAME FOUND')
+		let title = item.valueString || (item.valueInteger ? item.valueInteger.toString() : 'NO NAME FOUND');
 		// splits it
 		return title.split('#')[title.includes('# ') ? 1 : 0].trim()
 	}
@@ -343,18 +347,20 @@ class QuestionnaireModal extends Component {
 								onPress={() =>
 									this.props.actions.setAnswer({
 										linkId: item.linkId,
-										answer: answerOption.valueString || answerOption.valueInteger,
+										answer: answerOption.valueCoding || answerOption.valueString || answerOption.valueInteger,
 									})
 								}
 								onIconPress={() =>
 									this.props.actions.setAnswer({
 										linkId: item.linkId,
-										answer: answerOption.valueString || answerOption.valueInteger,
+										answer: answerOption.valueCoding || answerOption.valueString || answerOption.valueInteger,
 									})
 								}
 								checkedColor={config.theme.colors.primary}
 								uncheckedColor={config.theme.colors.accent1}
 								checked={
+									this.compareCoding(exportService.getCorrectlyFormatedAnswer(this.props.questionnaireItemMap[item.linkId]),
+										answerOption.valueCoding) ||
 									exportService.getCorrectlyFormatedAnswer(this.props.questionnaireItemMap[item.linkId]) ===
 										answerOption.valueString ||
 									exportService.getCorrectlyFormatedAnswer(this.props.questionnaireItemMap[item.linkId]) ===
@@ -369,6 +375,14 @@ class QuestionnaireModal extends Component {
 				</View>
 			</View>
 		) : null
+	}
+
+	compareCoding = (val1, val2) => {
+		if (val1 && val2) {
+			return val1.system === val2.system && val1.code === val2.code;
+		} else {
+			return false;
+		}
 	}
 
 	/**
@@ -398,18 +412,23 @@ class QuestionnaireModal extends Component {
 								onPress={() =>
 									this.props.actions.setAnswer({
 										linkId: item.linkId,
-										answer: answerOption.valueString || answerOption.valueInteger,
+										answer: answerOption.valueCoding || answerOption.valueString || answerOption.valueInteger,
 										openAnswer: true,
 									})
 								}
 								onIconPress={() =>
 									this.props.actions.setAnswer({
 										linkId: item.linkId,
-										answer: answerOption.valueString || answerOption.valueInteger,
+										answer: answerOption.valueCoding ||answerOption.valueString || answerOption.valueInteger,
 										openAnswer: true,
 									})
 								}
 								checked={
+									(this.props.questionnaireItemMap[item.linkId].answer &&
+										answerOption.valueCoding &&
+										this.props.questionnaireItemMap[item.linkId].answer.some(
+											c => c.code === answerOption.valueCoding.code && c.system === answerOption.valueCoding.system
+										)) ||
 									(this.props.questionnaireItemMap[item.linkId].answer &&
 										this.props.questionnaireItemMap[item.linkId].answer.includes(
 											answerOption.valueString

--- a/src/screens/checkIn/checkInReducer.js
+++ b/src/screens/checkIn/checkInReducer.js
@@ -136,16 +136,20 @@ const valuesHandlers = {
 			if (!Array.isArray(questionnaireItemMap[values.answer.linkId].answer)) {
 				questionnaireItemMap[values.answer.linkId].answer = []
 			}
+			let answers = questionnaireItemMap[values.answer.linkId].answer;
+
 			// removes the answer is already present
-			if (questionnaireItemMap[values.answer.linkId].answer.includes(values.answer.answer)) {
-				questionnaireItemMap[values.answer.linkId].answer.splice(
-					questionnaireItemMap[values.answer.linkId].answer.indexOf(values.answer.answer),
-					1
-				)
-			} 
+			let contained = false;
+			for(let i = answers.length -1 ; i>=0; i--) {
+				if(answers[i] === values.answer.answer ||
+					(typeof answers[i] === "object" && answers[i].code === values.answer.answer.code && answers[i].system === values.answer.answer.system)) {
+					answers.splice(i,1);
+					contained = true;
+				}
+			}
 			// adds the answer if not already present
-			else {
-				questionnaireItemMap[values.answer.linkId].answer.push(values.answer.answer)
+			if(!contained) {
+				answers.push(values.answer.answer)
 			}
 		} 
 		// if its just a single-value answer

--- a/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
+++ b/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
@@ -495,6 +495,27 @@ const createResponseJSON = () => {
 		
 		let newItems = []
 
+		function createAnswerObject(answer) {
+			if (typeof answer === "string") {
+				return {
+					valueString: answer,
+				};
+			} else if (typeof answer === "number") {
+				return {
+					valueInteger: answer
+				};
+			} else if(typeof answer === "object"){
+				return {
+					valueCoding: answer
+				}
+			} else { //null or undefined
+				return {
+					valueString: answer
+				}
+			}
+
+		}
+
 		if (items)
 			items.forEach(function(item) {
 				
@@ -553,10 +574,7 @@ const createResponseJSON = () => {
 							break
 
 						case 'choice':
-							answerObject = {
-								// either there is an answer, or just null
-								valueString: String(itemDetails.answer),
-							}
+							answerObject = createAnswerObject(itemDetails.answer);
 							// traverse the child-items, if there are any and add them to the answer
 							childItems = item.item ? createItems(item.item) : []
 							if (childItems.length !== 0) answerObject.item = childItems
@@ -570,9 +588,7 @@ const createResponseJSON = () => {
 								// see?
 								itemDetails.answer.forEach(function (answer) {
 									// so now we create an object for each set answer
-									answerObject = { 
-										valueString: answer 
-									}
+									answerObject = createAnswerObject(answer)
 									// and check if there are any child-items.
 									// if yes: traverse the child-items and add them to the answer
 									childItems = item.item ? createItems(item.item, answer): []


### PR DESCRIPTION
Currently, if there is literally any extension on an item of type integer or decimal, a slider gets rendered. This pull request should fix that issue.