### PR TITLE
Identify Questionnaires by concatenation of URL and VERSION, instead of the TITLE

### DIFF
--- a/src/screens/checkIn/checkInContainer.js
+++ b/src/screens/checkIn/checkInContainer.js
@@ -228,7 +228,7 @@ class CheckInContainer extends Component {
 			if(lastQuestionnaireId && !this.props.noNewQuestionnaireAvailableYet) {
 				// checks if the id of the persisted questionnaire matches the one of the
 				// questionnaire the user is supposed to look at now
-				if( config.appConfig.skipIncomingQuestionnaireCheck || lastQuestionnaireId === data.current_questionnaire_id) {
+				if(config.appConfig.skipIncomingQuestionnaireCheck || lastQuestionnaireId === data.current_questionnaire_id) {
 					// loads the persisted questionnaire
 					this.checkForCachedData()
 				}

--- a/src/screens/checkIn/checkInReducer.js
+++ b/src/screens/checkIn/checkInReducer.js
@@ -434,14 +434,15 @@ const generateQuestionnaireItemMap = (questionnaire, subjectId) => {
 	// used to determine if the questionnaire was even opened
 	questionnaireItemMap.started = false
 	// used to identify the questionnaire
-	questionnaireItemMap.id = questionnaire.title
-	// used to build the questionnaire-response
+	questionnaireItemMap.constructedId = questionnaire.url + "|" + questionnaire.version
 	questionnaireItemMap.url = questionnaire.url
+	questionnaireItemMap.version = questionnaire.version
+	// used to build the questionnaire-response
 	questionnaireItemMap.identifier = questionnaire.identifier
 
 	// persists the last known questionnaireId in the AsyncStorage
-	setTimeout(() => {
-		localStorage.persistLastQuestionnaireId(questionnaire.title, subjectId)
+	setTimeout(async () => {
+		localStorage.persistLastQuestionnaireId(questionnaireItemMap.constructedId, subjectId)
 	}, 0)
 
 	return questionnaireItemMap


### PR DESCRIPTION
Updates the checkinContainer so that it uses the concatenation of the questionnaire-attributes "url" and "version" (instead of just "title") to identify a specific questionnaire:

**[questionnaire.url] + "|" + [questionnaire.version]**
_(basically a **Canonical URL** with an attached version number: https://www.hl7.org/fhir/references.html#canonical)_

In consequence, the IDs used as PrivateKeys in the ProstgreSQL (to identify the questionnaires) would need to adhere to this scheme.