### PR TITLE
Support for FHIR extension-questionnaire-hidden

### DIFF
--- a/src/assets/files/questionnaire.js
+++ b/src/assets/files/questionnaire.js
@@ -557,7 +557,42 @@ export default {
                     }
                 },
             ],
-          } 
+          } ,
+          {
+              "linkId": "1.40",
+              "text": "Das ist eine Frage mit hidden-extension",
+              "type": "string",
+              "extension":[
+              {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
+                  "valueBoolean": true
+              }
+          ]
+          },
+          {
+            "linkId": "1.41",
+            "text": "Diese Frage besteht aus zwei Teilen. Der zweiter Teil wurde auf Hidden gesetzt und wird nicht angezeigt.",
+            "type": "group",
+            "required": true,
+            "item": [{
+                "linkId": "1.41.1",
+                "text": "Abfrage Datum",
+                "type": "date",
+                "required": true
+            },
+                {
+                    "linkId": "1.41.2",
+                    "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
+                    "type": "string",
+                    "extension":[
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
+                            "valueBoolean": true
+                        }
+                    ]
+                }
+            ]
+        }
        ]
     }, 
        

--- a/src/components/modal/questionnaireModal.js
+++ b/src/components/modal/questionnaireModal.js
@@ -343,9 +343,8 @@ class QuestionnaireModal extends Component {
 
 				{ item.extension && 
 				item.extension[0].valueCodeableConcept && 
-				item.extension[0].valueCodeableConcept.CodeableConcept && 
-				item.extension[0].valueCodeableConcept.CodeableConcept.coding &&
-				item.extension[0].valueCodeableConcept.CodeableConcept.coding[0].code === "drop-down" ? 
+				item.extension[0].valueCodeableConcept.coding &&
+				item.extension[0].valueCodeableConcept.coding[0].code === "drop-down" ? 
 				<View>
 					<Picker
 						selectedValue={this.props.questionnaireItemMap[item.linkId].answer}

--- a/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
+++ b/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
@@ -398,9 +398,13 @@ const checkDependenciesOfSingleItem = item => {
 	let returnValue = false
 
 	let props = store.getState().CheckIn
-
+	
+	//if item is supposed to be hidden
+	if(item.extension && item.extension[0].valueBoolean && item.extension[0].valueBoolean === true){
+		returnValue = false
+	}
 	// if the item has a set of conditions
-	if (item && item.enableWhen) {
+	else if (item && item.enableWhen) {
 
 		// checks if the items mentioned in the conditions are even answered...
 		if (!checkIfAnswersToConditionsAreAvailable (item )) {


### PR DESCRIPTION
After #19 the drop-down from the extension questionnaire-item-controll wasn't render properly.
In Addition the extension-questionnaire-hidden is implemented.