### PR TITLE
Updating Choice- and Ope-Choice Handling

### DIFF
--- a/src/assets/files/questionnaire.js
+++ b/src/assets/files/questionnaire.js
@@ -15,636 +15,114 @@ export default {
     "date": "2021-01-25",
     "publisher": "IBM",
     "purpose": "Abbildung der aktuell in der von IBM entwickelten App unterstützten FHIR Funktionalitäten",
-    "item": [{
-        "linkId": "1",
-        "text": "Fragegruppe 1",
-        "type": "group",
-        "required": true,
-        "item": [{
-            "linkId": "1.1",
-            "text": "Das ist eine Freitextabfrage",
-            "type": "string",
-            "required": true
-        },
-            {
-                "linkId": "1.2",
-                "text": "Das ist eine Datumsabfrage",
-                "type": "date",
-                "required": true
-            },
-            {
-                "linkId": "1.3",
-                "text": "Das ist eine Dezimalzahlenabfrage",
-                "type": "decimal",
-                "required": true
-            },
-            {
-                "linkId": "1.4",
-                "text": "Das ist eine Ganzzahlenabfrage",
-                "type": "integer",
-                "required": true
-            },
-            {
-                "linkId": "1.5",
-                "text": "Das ist eine boolsche Abfrage",
-                "type": "boolean",
-                "required": true
-            },
-            {
-                "linkId": "1.6",
-                "text": "Das ist eine informative Anzeige ohne Abfrage",
-                "type": "display",
-                "required": true
-            }, {
-                "linkId": "1.7",
-                "text": "Das ist eine Slider-Abfrage",
-                "type": "integer",
-                "extension": [{
-                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                    "valueCodeableConcept": {
-                        "coding": [{
-                            "system": "http://hl7.org/fhir/questionnaire-item-control",
-                            "code": "slider"
-                        }]
-                    }
-                },
-                    {
-                        "url": "https://num-compass.science/fhir/StructureDefinition/LowRangeLabel",
-                        "valueString": "Niedrig"
-                    },
-                    {
-                        "url": "https://num-compass.science/fhir/StructureDefinition/HighRangeLabel",
-                        "valueString": "Hoch"
-                    },
-                    {
-                        "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-sliderStepValue",
-                        "valueInteger": 1
-                    },
-                    {
-                        "url": "http://hl7.org/fhir/StructureDefinition/minValue",
-                        "valueInteger": 0
-                    },
-                    {
-                        "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
-                        "valueInteger": 10
-                    }
-                ],
-                "required": true
-            },
-            {
-                "linkId": "1.8",
-                "text": "Das ist eine optionale Frage",
-                "type": "string",
-                "required": false
-            },
-            {
-                "linkId": "1.9",
-                "text": "Das ist eine Multiple-Choice-Abfrage",
-                "type": "open-choice",
-                "required": true,
-                "answerOption": [{
-                    "valueString": "Option A"
-                },
-                    {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    }
-                ]
-            },
-            {
-                "linkId": "1.10",
-                "text": "Das ist eine alternative Art eine Multiple-Choice-Abfrage abzubilden",
-                "type": "group",
-                "required": true,
-                "item": [{
-                    "linkId": "1.10.1",
-                    "text": "Option A",
-                    "type": "boolean",
-                    "required": true
-                },
-                    {
-                        "linkId": "1.10.2",
-                        "text": "Option B",
-                        "type": "boolean",
-                        "required": true
-                    },
-                    {
-                        "linkId": "1.10.3",
-                        "text": "Option C",
-                        "type": "boolean",
-                        "required": true
-                    }
-                ]
-            },
-            {
-                "linkId": "1.11",
-                "text": "Das ist eine Single-Choice-Abfrage",
-                "type": "choice",
-                "required": true,
-                "answerOption": [{
-                    "valueString": "Option A"
-                },
-                    {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    }
-                ]
-            },
-            {
-                "linkId": "1.12",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.11 mit Option A beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.11",
-                    "operator": "=",
-                    "answerString": "Option A"
-                }]
-            },
-            {
-                "linkId": "1.13",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.11 oder 1.10.1 mit Option A beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.10.1",
-                    "operator": "=",
-                    "answerBoolean": true
-                }, {
-                    "question": "1.11",
-                    "operator": "=",
-                    "answerString": "Option A"
-                }],
-                "enableBehavior": "any"
-            },
-            {
-                "linkId": "1.14",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.11 und 1.10.1 mit Option A beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.10.1",
-                    "operator": "=",
-                    "answerBoolean": true
-                }, {
-                    "question": "1.11",
-                    "operator": "=",
-                    "answerString": "Option A"
-                }],
-                "enableBehavior": "all"
-            },
-            {
-                "linkId": "1.15",
-                "text": "Bedingte Abfrage mit answerDecimal",
-                "type": "group",
-                "required": true,
-                "item": [{
-                    "linkId": "1.15.1",
-                    "text": "Abfrage Dezimalzahl (erwartet = 1.5)",
-                    "type": "decimal",
-                    "required": true
-                },
-                    {
-                        "linkId": "1.15.2",
-                        "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
-                        "type": "string",
-                        "required": true,
-                        "enableWhen": [{
-                            "question": "1.15.1",
-                            "operator": "=",
-                            "answerDecimal": 1.5
-                        }]
-                    }
-                ]
-            },
-            {
-                "linkId": "1.16",
-                "text": "Bedingte Abfrage mit answerInteger",
-                "type": "group",
-                "required": true,
-                "item": [{
-                    "linkId": "1.16.1",
-                    "text": "Abfrage Ganzzahl (erwartet = 1)",
-                    "type": "integer",
-                    "required": true
-                },
-                    {
-                        "linkId": "1.16.2",
-                        "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
-                        "type": "string",
-                        "required": true,
-                        "enableWhen": [{
-                            "question": "1.16.1",
-                            "operator": "=",
-                            "answerInteger": 1
-                        }]
-                    }
-                ]
-            },
-            {
-                "linkId": "1.17",
-                "text": "Bedingte Abfrage mit answerDate",
-                "type": "group",
-                "required": true,
-                "item": [{
-                    "linkId": "1.17.1",
-                    "text": "Abfrage Datum (erwartet = 01.01.2021)",
-                    "type": "date",
-                    "required": true
-                },
-                    {
-                        "linkId": "1.17.2",
-                        "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
-                        "type": "string",
-                        "required": true,
-                        "enableWhen": [{
-                            "question": "1.17.1",
-                            "operator": "=",
-                            "answerDate": "2021-01-01"
-                        }]
-                    }
-                ]
-            },
-            {
-                "linkId": "1.18",
-                "text": "Das ist eine Frage mit Definition",
-                "type": "string",
-                "required": true,
-                "definition": "http://loinc.org/example#uri"
-            },
-            {
-                "linkId": "1.19",
-                "text": "Das ist eine Frage mit max. Eingabelänge von 10 Zeichen",
-                "type": "string",
-                "required": true,
-                "maxLength": 10
-            },
-            {
-                "linkId": "1.20",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.21",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.22",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.23",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.24",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.25",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.26",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.27",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.28",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.29",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.30",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.31",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.32",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.33",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.34",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.35",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.36",
-                "text": "Diese Frage wird nur angezeigt, wenn 1.19 mit 'lala' beantwortet wurde",
-                "type": "string",
-                "required": true,
-                "enableWhen": [{
-                    "question": "1.19",
-                    "operator": "=",
-                    "answerString": "lala"
-                }]
-            },
-            {
-                "linkId": "1.37",
-                "text": "Das ist eine Multiple-Choice-Abfrage mit Coding",
-                "type": "open-choice",
-                "required": true,
-                "answerOption": [{
-                        "valueCoding": {
-                            "system": "snomed", "code": "A", "display": "Alpha"
-                        }
-                    },
-                    {
-                        "valueCoding": {
-                            "system": "snomed", "code": "B", "display": "Beta"
-                        }
-                    },
-                    {
-                        "valueCoding": {
-                            "system": "snomed", "code": "C", "display": "Gamma"
-                        }
-                    }
-                ]
-            },
-            {
-                "linkId": "1.38",
-                "text": "Das ist eine Single-Choice-Abfrage mit Coding",
-                "type": "choice",
-                "required": true,
-                "answerOption": [{
-                        "valueCoding": {
-                            "system": "snomed", "code": "A", "display": "Alpha"
-                        }
-                    },
-                    {
-                        "valueCoding": {
-                            "system": "snomed", "code": "B", "display": "Beta"
-                        }
-                    },
-                    {
-                        "valueCoding": {
-                            "system": "snomed", "code": "C", "display": "Gamma"
-                        }
-                    }
-                ]
-            },
-            {
-                "linkId": "1.39",
-                "text": "Das ist eine Single-Choice-Abfrage als Drop-Down",
-                "type": "choice",
-                "required": true,
-                "answerOption": [{
-                        "valueString": "Option A"
-                    },
-                    {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    },
-                    {
-                        "valueString": "Option D"
-                    },
-                    {
-                        "valueString": "Option E"
-                    },
-                    {
-                        "valueString": "Option F"
-                    },
-                    {
-                        "valueString": "Option G"
-                    },
-                    {
-                        "valueString": "Option H"
-                    },
-                    {
-                        "valueString": "Option I"
-                    }
-                ],
-                "extension": [{
-                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                    "valueCodeableConcept": {
-                        "coding": [{
-                            "system": "http://hl7.org/fhir/questionnaire-item-control",
-                            "code": "drop-down"
-                        }]
-                    }
-                },
-            ],
-          } ,
-          {
-              "linkId": "1.40",
-              "text": "Das ist eine Frage mit hidden-extension",
-              "type": "string",
-              "extension":[
-              {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
-                  "valueBoolean": true
-              }
-          ]
-          },
-          {
-            "linkId": "1.41",
-            "text": "Diese Frage besteht aus zwei Teilen. Der zweiter Teil wurde auf Hidden gesetzt und wird nicht angezeigt.",
+    "item": [
+        {
+            "linkId": "1",
+            "text": "Fragegruppe 1",
             "type": "group",
             "required": true,
-            "item": [{
-                "linkId": "1.41.1",
-                "text": "Abfrage Datum",
-                "type": "date",
-                "required": true
-            },
+            "item": [
                 {
-                    "linkId": "1.41.2",
-                    "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
-                    "type": "string",
-                    "extension":[
+                    "linkId": "1.1",
+                    "text": "Das ist eine Choice-Abfrage ohne Repeat",
+                    "type": "choice",
+                    "required": true,
+                    "repeats": false,
+                    "answerOption": [
                         {
-                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
-                            "valueBoolean": true
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        },
+                        {
+                            "valueString": "Option D"
+                        },
+                        {
+                            "valueString": "Option E"
+                        },
+                        {
+                            "valueString": "Option F"
+                        },
+                        {
+                            "valueString": "Option G"
+                        },
+                        {
+                            "valueString": "Option H"
+                        },
+                        {
+                            "valueString": "Option I"
+                        }
+                    ],
+                    "item": [
+                        {
+                            "linkId": "1.1.1",
+                            "text": "test-abfrage",
+                            "type": "string",
+                            "enableWhen": [{
+                                "question": "1.1",
+                                "operator": "=",
+                                "answerString": "Option A"
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.2",
+                    "text": "Das ist eine Choice-Abfrage mit Repeat",
+                    "type": "choice",
+                    "required": true,
+                    "repeats": true,
+                    "answerOption": [
+                        {
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        },
+                        {
+                            "valueString": "Option D"
+                        },
+                        {
+                            "valueString": "Option E"
+                        },
+                        {
+                            "valueString": "Option F"
+                        },
+                        {
+                            "valueString": "Option G"
+                        },
+                        {
+                            "valueString": "Option H"
+                        },
+                        {
+                            "valueString": "Option I"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.3",
+                    "text": "Das ist eine Open-Choice-Abfrage",
+                    "type": "open-choice",
+                    "required": true,
+                    "answerOption": [{
+                        "valueString": "Option A"
+                    },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
                         }
                     ]
                 }
             ]
         }
-       ]
-    }, 
-       
-       {
-        "linkId": "2",
-        "text": "Fragegruppe 2",
-        "type": "group",
-        "required": true,
-        "item": [{
-            "linkId": "2.1",
-            "text": "Untergruppe 1",
-            "type": "group",
-            "required": true,
-            "item": [{
-                "linkId": "2.1.1",
-                "text": "Untergruppe 2",
-                "type": "group",
-                "required": true,
-                "item": [{
-                    "linkId": "2.1.1.1",
-                    "text": "Frage der Untergruppe 2",
-                    "type": "string",
-                    "required": true
-                },
-                    {
-                        "linkId": "2.1.1.2",
-                        "text": "Untergruppe 3",
-                        "type": "group",
-                        "required": true,
-                        "item": [{
-                            "linkId": "2.1.1.2.1",
-                            "text": "Frage 1 der Untergruppe 3",
-                            "type": "string",
-                            "required": true
-                        },
-                            {
-                                "linkId": "2.1.1.2.2",
-                                "text": "Frage 2 der Untergruppe 3",
-                                "type": "string",
-                                "required": true
-                            }
-                        ]
-                    }
-                ]
-            },
-                {
-                    "linkId": "2.1.2",
-                    "text": "Frage der Untergruppe 1",
-                    "type": "boolean",
-                    "required": true
-                }
-            ]
-        }]
-    }]
+    ]
 }

--- a/src/assets/files/questionnaire.js
+++ b/src/assets/files/questionnaire.js
@@ -16,113 +16,527 @@ export default {
     "publisher": "IBM",
     "purpose": "Abbildung der aktuell in der von IBM entwickelten App unterstützten FHIR Funktionalitäten",
     "item": [{
-        "linkId": "1",
-        "text": "Fragegruppe 1",
-        "type": "group",
-        "required": true,
-        "item": [{
-                "linkId": "1.1",
-                "text": "Das ist eine Choice-Abfrage ohne Repeat",
-                "type": "choice",
+            "linkId": "1",
+            "text": "Fragegruppe 1",
+            "type": "group",
+            "required": true,
+            "item": [{
+                    "linkId": "1.1",
+                    "text": "Das ist eine Freitextabfrage",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "linkId": "1.2",
+                    "text": "Das ist eine Datumsabfrage",
+                    "type": "date",
+                    "required": true
+                },
+                {
+                    "linkId": "1.3",
+                    "text": "Das ist eine Dezimalzahlenabfrage",
+                    "type": "decimal",
+                    "required": true
+                },
+                {
+                    "linkId": "1.4",
+                    "text": "Das ist eine Ganzzahlenabfrage",
+                    "type": "integer",
+                    "required": true
+                },
+                {
+                    "linkId": "1.5",
+                    "text": "Das ist eine boolsche Abfrage",
+                    "type": "boolean",
+                    "required": true
+                },
+                {
+                    "linkId": "1.6",
+                    "text": "Das ist eine informative Anzeige ohne Abfrage",
+                    "type": "display",
+                    "required": true
+                }, {
+                    "linkId": "1.7",
+                    "text": "Das ist eine Slider-Abfrage",
+                    "type": "integer",
+                    "extension": [{
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [{
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                    "code": "slider"
+                                }]
+                            }
+                        },
+                        {
+                            "url": "https://num-compass.science/fhir/StructureDefinition/LowRangeLabel",
+                            "valueString": "Niedrig"
+                        },
+                        {
+                            "url": "https://num-compass.science/fhir/StructureDefinition/HighRangeLabel",
+                            "valueString": "Hoch"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-sliderStepValue",
+                            "valueInteger": 1
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/minValue",
+                            "valueInteger": 0
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
+                            "valueInteger": 10
+                        }
+                    ],
+                    "required": true
+                },
+                {
+                    "linkId": "1.8",
+                    "text": "Das ist eine optionale Frage",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "linkId": "1.9",
+                    "text": "Das ist eine Choice-Abfrage mit Repeat",
+                    "type": "choice",
+                    "required": true,
+                    "repeats": true,
+                    "answerOption": [{
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        },
+                        {
+                            "valueString": "Option D"
+                        },
+                        {
+                            "valueString": "Option E"
+                        },
+                        {
+                            "valueString": "Option F"
+                        },
+                        {
+                            "valueString": "Option G"
+                        },
+                        {
+                            "valueString": "Option H"
+                        },
+                        {
+                            "valueString": "Option I"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.10",
+                    "text": "Das ist eine Gruppe aus Booleans (kein Choice Element)",
+                    "type": "group",
+                    "required": true,
+                    "item": [{
+                            "linkId": "1.10.1",
+                            "text": "Option A",
+                            "type": "boolean",
+                            "required": true
+                        },
+                        {
+                            "linkId": "1.10.2",
+                            "text": "Option B",
+                            "type": "boolean",
+                            "required": true
+                        },
+                        {
+                            "linkId": "1.10.3",
+                            "text": "Option C",
+                            "type": "boolean",
+                            "required": true
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.11",
+                    "text": "Das ist eine Choice-Abfrage ohne Repeat",
+                    "type": "choice",
+                    "required": true,
+                    "repeats": false,
+                    "answerOption": [{
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        },
+                        {
+                            "valueString": "Option D"
+                        },
+                        {
+                            "valueString": "Option E"
+                        },
+                        {
+                            "valueString": "Option F"
+                        },
+                        {
+                            "valueString": "Option G"
+                        },
+                        {
+                            "valueString": "Option H"
+                        },
+                        {
+                            "valueString": "Option I"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.12",
+                    "text": "Diese Frage wird nur angezeigt, wenn 1.11 mit Option A beantwortet wurde",
+                    "type": "string",
+                    "required": true,
+                    "enableWhen": [{
+                        "question": "1.11",
+                        "operator": "=",
+                        "answerString": "Option A"
+                    }]
+                },
+                {
+                    "linkId": "1.13",
+                    "text": "Diese Frage wird nur angezeigt, wenn 1.11 oder 1.10.1 mit Option A beantwortet wurde",
+                    "type": "string",
+                    "required": true,
+                    "enableWhen": [{
+                        "question": "1.10.1",
+                        "operator": "=",
+                        "answerBoolean": true
+                    }, {
+                        "question": "1.11",
+                        "operator": "=",
+                        "answerString": "Option A"
+                    }],
+                    "enableBehavior": "any"
+                },
+                {
+                    "linkId": "1.14",
+                    "text": "Diese Frage wird nur angezeigt, wenn 1.11 und 1.10.1 mit Option A beantwortet wurde",
+                    "type": "string",
+                    "required": true,
+                    "enableWhen": [{
+                        "question": "1.10.1",
+                        "operator": "=",
+                        "answerBoolean": true
+                    }, {
+                        "question": "1.11",
+                        "operator": "=",
+                        "answerString": "Option A"
+                    }],
+                    "enableBehavior": "all"
+                },
+                {
+                    "linkId": "1.15",
+                    "text": "Bedingte Abfrage mit answerDecimal",
+                    "type": "group",
+                    "required": true,
+                    "item": [{
+                            "linkId": "1.15.1",
+                            "text": "Abfrage Dezimalzahl (erwartet = 1.5)",
+                            "type": "decimal",
+                            "required": true
+                        },
+                        {
+                            "linkId": "1.15.2",
+                            "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
+                            "type": "string",
+                            "required": true,
+                            "enableWhen": [{
+                                "question": "1.15.1",
+                                "operator": "=",
+                                "answerDecimal": 1.5
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.16",
+                    "text": "Bedingte Abfrage mit answerInteger",
+                    "type": "group",
+                    "required": true,
+                    "item": [{
+                            "linkId": "1.16.1",
+                            "text": "Abfrage Ganzzahl (erwartet = 1)",
+                            "type": "integer",
+                            "required": true
+                        },
+                        {
+                            "linkId": "1.16.2",
+                            "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
+                            "type": "string",
+                            "required": true,
+                            "enableWhen": [{
+                                "question": "1.16.1",
+                                "operator": "=",
+                                "answerInteger": 1
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.17",
+                    "text": "Bedingte Abfrage mit answerDate",
+                    "type": "group",
+                    "required": true,
+                    "item": [{
+                            "linkId": "1.17.1",
+                            "text": "Abfrage Datum (erwartet = 01.01.2021)",
+                            "type": "date",
+                            "required": true
+                        },
+                        {
+                            "linkId": "1.17.2",
+                            "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
+                            "type": "string",
+                            "required": true,
+                            "enableWhen": [{
+                                "question": "1.17.1",
+                                "operator": "=",
+                                "answerDate": "2021-01-01"
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.18",
+                    "text": "Das ist eine Frage mit Definition",
+                    "type": "string",
+                    "required": true,
+                    "definition": "http://loinc.org/example#uri"
+                },
+                {
+                    "linkId": "1.19",
+                    "text": "Das ist eine Frage mit max. Eingabelänge von 10 Zeichen",
+                    "type": "string",
+                    "required": true,
+                    "maxLength": 10
+                },
+                {
+                    "linkId": "1.20",
+                    "text": "Das ist eine Open-Choice-Abfrage mit Coding",
+                    "type": "open-choice",
+                    "required": true,
+                    "answerOption": [{
+                            "valueCoding": {
+                                "system": "snomed",
+                                "code": "A",
+                                "display": "Alpha"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "snomed",
+                                "code": "B",
+                                "display": "Beta"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "snomed",
+                                "code": "C",
+                                "display": "Gamma"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.21",
+                    "text": "Das ist eine Single-Choice-Abfrage mit Coding",
+                    "type": "choice",
+                    "required": true,
+                    "answerOption": [{
+                            "valueCoding": {
+                                "system": "snomed",
+                                "code": "A",
+                                "display": "Alpha"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "snomed",
+                                "code": "B",
+                                "display": "Beta"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "snomed",
+                                "code": "C",
+                                "display": "Gamma"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.22",
+                    "text": "Das ist eine Single-Choice-Abfrage als Drop-Down",
+                    "type": "choice",
+                    "required": true,
+                    "answerOption": [{
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        },
+                        {
+                            "valueString": "Option D"
+                        },
+                        {
+                            "valueString": "Option E"
+                        },
+                        {
+                            "valueString": "Option F"
+                        },
+                        {
+                            "valueString": "Option G"
+                        },
+                        {
+                            "valueString": "Option H"
+                        },
+                        {
+                            "valueString": "Option I"
+                        }
+                    ],
+                    "extension": [{
+                        "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                        "valueCodeableConcept": {
+                            "coding": [{
+                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                "code": "drop-down"
+                            }]
+                        }
+                    }, ],
+                },
+                {
+                    "linkId": "1.23",
+                    "text": "Das ist eine Frage mit hidden-extension",
+                    "type": "string",
+                    "extension": [{
+                        "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
+                        "valueBoolean": true
+                    }]
+                },
+                {
+                    "linkId": "1.24",
+                    "text": "Diese Frage besteht aus zwei Teilen. Der zweiter Teil wurde auf Hidden gesetzt und wird nicht angezeigt.",
+                    "type": "group",
+                    "required": true,
+                    "item": [{
+                            "linkId": "1.24.1",
+                            "text": "Abfrage Datum",
+                            "type": "date",
+                            "required": true
+                        },
+                        {
+                            "linkId": "1.24.2",
+                            "text": "Diese Frage wird nur bei erwarteter Eingabe angezeigt",
+                            "type": "string",
+                            "extension": [{
+                                "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
+                                "valueBoolean": true
+                            }]
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.25",
+                    "text": "Das ist eine Open-Choice-Abfrage ohne Repeat",
+                    "type": "open-choice",
+                    "required": true,
+                    "answerOption": [{
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "1.26",
+                    "text": "Das ist eine Open-Choice-Abfrage mit Repeat",
+                    "type": "open-choice",
+                    "repeats": true,
+                    "required": true,
+                    "answerOption": [{
+                            "valueString": "Option A"
+                        },
+                        {
+                            "valueString": "Option B"
+                        },
+                        {
+                            "valueString": "Option C"
+                        }
+                    ]
+                }
+            ]
+        },
+
+        {
+            "linkId": "2",
+            "text": "Fragegruppe 2",
+            "type": "group",
+            "required": true,
+            "item": [{
+                "linkId": "2.1",
+                "text": "Untergruppe 1",
+                "type": "group",
                 "required": true,
-                "repeats": false,
-                "answerOption": [{
-                        "valueString": "Option A"
+                "item": [{
+                        "linkId": "2.1.1",
+                        "text": "Untergruppe 2",
+                        "type": "group",
+                        "required": true,
+                        "item": [{
+                                "linkId": "2.1.1.1",
+                                "text": "Frage der Untergruppe 2",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "linkId": "2.1.1.2",
+                                "text": "Untergruppe 3",
+                                "type": "group",
+                                "required": true,
+                                "item": [{
+                                        "linkId": "2.1.1.2.1",
+                                        "text": "Frage 1 der Untergruppe 3",
+                                        "type": "string",
+                                        "required": true
+                                    },
+                                    {
+                                        "linkId": "2.1.1.2.2",
+                                        "text": "Frage 2 der Untergruppe 3",
+                                        "type": "string",
+                                        "required": true
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    },
-                    {
-                        "valueString": "Option D"
-                    },
-                    {
-                        "valueString": "Option E"
-                    },
-                    {
-                        "valueString": "Option F"
-                    },
-                    {
-                        "valueString": "Option G"
-                    },
-                    {
-                        "valueString": "Option H"
-                    },
-                    {
-                        "valueString": "Option I"
+                        "linkId": "2.1.2",
+                        "text": "Frage der Untergruppe 1",
+                        "type": "boolean",
+                        "required": true
                     }
                 ]
-            },
-            {
-                "linkId": "1.2",
-                "text": "Das ist eine Choice-Abfrage mit Repeat",
-                "type": "choice",
-                "required": true,
-                "repeats": true,
-                "answerOption": [{
-                        "valueString": "Option A"
-                    },
-                    {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    },
-                    {
-                        "valueString": "Option D"
-                    },
-                    {
-                        "valueString": "Option E"
-                    },
-                    {
-                        "valueString": "Option F"
-                    },
-                    {
-                        "valueString": "Option G"
-                    },
-                    {
-                        "valueString": "Option H"
-                    },
-                    {
-                        "valueString": "Option I"
-                    }
-                ]
-            },
-            {
-                "linkId": "1.3",
-                "text": "Das ist eine Open-Choice-Abfrage ohne Repeat",
-                "type": "open-choice",
-                "required": true,
-                "answerOption": [{
-                        "valueString": "Option A"
-                    },
-                    {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    }
-                ]
-            },
-            {
-                "linkId": "1.4",
-                "text": "Das ist eine Open-Choice-Abfrage mit Repeat",
-                "type": "open-choice",
-                "repeats": true,
-                "required": true,
-                "answerOption": [{
-                        "valueString": "Option A"
-                    },
-                    {
-                        "valueString": "Option B"
-                    },
-                    {
-                        "valueString": "Option C"
-                    }
-                ]
-            }
-        ]
-    }]
+            }]
+        }
+    ]
 }

--- a/src/assets/files/questionnaire.js
+++ b/src/assets/files/questionnaire.js
@@ -15,114 +15,114 @@ export default {
     "date": "2021-01-25",
     "publisher": "IBM",
     "purpose": "Abbildung der aktuell in der von IBM entwickelten App unterstützten FHIR Funktionalitäten",
-    "item": [
-        {
-            "linkId": "1",
-            "text": "Fragegruppe 1",
-            "type": "group",
-            "required": true,
-            "item": [
-                {
-                    "linkId": "1.1",
-                    "text": "Das ist eine Choice-Abfrage ohne Repeat",
-                    "type": "choice",
-                    "required": true,
-                    "repeats": false,
-                    "answerOption": [
-                        {
-                            "valueString": "Option A"
-                        },
-                        {
-                            "valueString": "Option B"
-                        },
-                        {
-                            "valueString": "Option C"
-                        },
-                        {
-                            "valueString": "Option D"
-                        },
-                        {
-                            "valueString": "Option E"
-                        },
-                        {
-                            "valueString": "Option F"
-                        },
-                        {
-                            "valueString": "Option G"
-                        },
-                        {
-                            "valueString": "Option H"
-                        },
-                        {
-                            "valueString": "Option I"
-                        }
-                    ],
-                    "item": [
-                        {
-                            "linkId": "1.1.1",
-                            "text": "test-abfrage",
-                            "type": "string",
-                            "enableWhen": [{
-                                "question": "1.1",
-                                "operator": "=",
-                                "answerString": "Option A"
-                            }]
-                        }
-                    ]
-                },
-                {
-                    "linkId": "1.2",
-                    "text": "Das ist eine Choice-Abfrage mit Repeat",
-                    "type": "choice",
-                    "required": true,
-                    "repeats": true,
-                    "answerOption": [
-                        {
-                            "valueString": "Option A"
-                        },
-                        {
-                            "valueString": "Option B"
-                        },
-                        {
-                            "valueString": "Option C"
-                        },
-                        {
-                            "valueString": "Option D"
-                        },
-                        {
-                            "valueString": "Option E"
-                        },
-                        {
-                            "valueString": "Option F"
-                        },
-                        {
-                            "valueString": "Option G"
-                        },
-                        {
-                            "valueString": "Option H"
-                        },
-                        {
-                            "valueString": "Option I"
-                        }
-                    ]
-                },
-                {
-                    "linkId": "1.3",
-                    "text": "Das ist eine Open-Choice-Abfrage",
-                    "type": "open-choice",
-                    "required": true,
-                    "answerOption": [{
+    "item": [{
+        "linkId": "1",
+        "text": "Fragegruppe 1",
+        "type": "group",
+        "required": true,
+        "item": [{
+                "linkId": "1.1",
+                "text": "Das ist eine Choice-Abfrage ohne Repeat",
+                "type": "choice",
+                "required": true,
+                "repeats": false,
+                "answerOption": [{
                         "valueString": "Option A"
                     },
-                        {
-                            "valueString": "Option B"
-                        },
-                        {
-                            "valueString": "Option C"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+                    {
+                        "valueString": "Option B"
+                    },
+                    {
+                        "valueString": "Option C"
+                    },
+                    {
+                        "valueString": "Option D"
+                    },
+                    {
+                        "valueString": "Option E"
+                    },
+                    {
+                        "valueString": "Option F"
+                    },
+                    {
+                        "valueString": "Option G"
+                    },
+                    {
+                        "valueString": "Option H"
+                    },
+                    {
+                        "valueString": "Option I"
+                    }
+                ]
+            },
+            {
+                "linkId": "1.2",
+                "text": "Das ist eine Choice-Abfrage mit Repeat",
+                "type": "choice",
+                "required": true,
+                "repeats": true,
+                "answerOption": [{
+                        "valueString": "Option A"
+                    },
+                    {
+                        "valueString": "Option B"
+                    },
+                    {
+                        "valueString": "Option C"
+                    },
+                    {
+                        "valueString": "Option D"
+                    },
+                    {
+                        "valueString": "Option E"
+                    },
+                    {
+                        "valueString": "Option F"
+                    },
+                    {
+                        "valueString": "Option G"
+                    },
+                    {
+                        "valueString": "Option H"
+                    },
+                    {
+                        "valueString": "Option I"
+                    }
+                ]
+            },
+            {
+                "linkId": "1.3",
+                "text": "Das ist eine Open-Choice-Abfrage ohne Repeat",
+                "type": "open-choice",
+                "required": true,
+                "answerOption": [{
+                        "valueString": "Option A"
+                    },
+                    {
+                        "valueString": "Option B"
+                    },
+                    {
+                        "valueString": "Option C"
+                    }
+                ]
+            },
+            {
+                "linkId": "1.4",
+                "text": "Das ist eine Open-Choice-Abfrage mit Repeat",
+                "type": "open-choice",
+                "repeats": true,
+                "required": true,
+                "answerOption": [{
+                        "valueString": "Option A"
+                    },
+                    {
+                        "valueString": "Option B"
+                    },
+                    {
+                        "valueString": "Option C"
+                    }
+                ]
+            }
+        ]
+    }]
 }

--- a/src/components/modal/questionnaireModal.js
+++ b/src/components/modal/questionnaireModal.js
@@ -381,7 +381,7 @@ class QuestionnaireModal extends Component {
 					:
 					(
 						<View>
-							{/* repeat: true */}
+							{/* repeat: false */}
 							{!item.repeats && (
 								<View>
 									{/* renders a list of answers */}

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -82,7 +82,7 @@ const conf = {
 	/** dev-option:
 	 * logs out the response-json parsed as an object in the developer console
 	 * */
-	logPureResponse: __DEV__ && false,
+	logPureResponse: __DEV__ && true,
 
 	/** dev-option:
 	 * logs out the response-json in the developer console

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -82,7 +82,7 @@ const conf = {
 	/** dev-option:
 	 * logs out the response-json parsed as an object in the developer console
 	 * */
-	logPureResponse: __DEV__ && true,
+	logPureResponse: __DEV__ && false,
 
 	/** dev-option:
 	 * logs out the response-json in the developer console

--- a/src/config/textConfig.js
+++ b/src/config/textConfig.js
@@ -172,7 +172,9 @@ export default {
 
 	/** strings of the survey-screen */
 	"survey":{
+		"subTitle":"",
 		"logout":"logout",
+		"subTitleCheckIn":"",
 		"title":"Questionnaire",
 		"isLoading":"loading...",
 		"yourAnswer":"your answer",
@@ -181,12 +183,12 @@ export default {
 		"noUserTitle":"User not found",
 		"sendFinished":"send questionnaire",
 		"send":"Send Questionnaire Button Title",
-		"subTitle":"",
+		"additionalAnswer": "zusätzliche Antwort",
+		"alternativeAnswer": "alternative Antwort",
 		"surveySubTitle":"To be completed till:  ",
 		"surveyTitle":"Your current questionnaire",
 		"inputPlaceholder":"please enter your answer",
 		"noQuestionnaireTitle":"Questionnaire not found",
-		"subTitleCheckIn":"",
 		"loadingQuestionnaire":"requesting\nquestionnaire",
 		"inputPlaceholderTime":"please enter the date here",
 		"sessionTimeout":"Your user could not re recognized",

--- a/src/screens/checkIn/checkInContainer.js
+++ b/src/screens/checkIn/checkInContainer.js
@@ -396,6 +396,10 @@ class CheckInContainer extends Component {
 	 * checks if the questionnaire was completed and if true triggers the export
 	 */
 	exportAndUploadQuestionnaireResponse = () => {
+
+		documentCreator.createResponseJSON()
+		return
+
 		// if the questionnaire was NOT completed
 		if(this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done) {
 			// shows a message remembering the user to complete the questionnaire

--- a/src/screens/checkIn/checkInContainer.js
+++ b/src/screens/checkIn/checkInContainer.js
@@ -397,9 +397,6 @@ class CheckInContainer extends Component {
 	 */
 	exportAndUploadQuestionnaireResponse = () => {
 
-		documentCreator.createResponseJSON()
-		return
-
 		// if the questionnaire was NOT completed
 		if(this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done) {
 			// shows a message remembering the user to complete the questionnaire

--- a/src/screens/checkIn/checkInReducer.js
+++ b/src/screens/checkIn/checkInReducer.js
@@ -162,8 +162,20 @@ const valuesHandlers = {
 		} 
 		// if its just a single-value answer
 		else {
-			// just updates the answer value
-			questionnaireItemMap[values.answer.linkId].answer = values.answer.answer
+
+			// nulls an empty string
+			if(typeof values.answer.answer === 'string' && !values.answer.answer) values.answer.answer = null
+
+			// writes the open-answer value in a separate variable
+			if(values.answer.isOpenAnswer) {
+				let answer = questionnaireItemMap[values.answer.linkId].answerOption.filter(e => e.isOpenQuestionAnswer)[0]
+				answer.answer = values.answer.answer
+			}
+
+			if(!values.answer.isAdditionalAnswer) {
+				// just updates the answer value
+				questionnaireItemMap[values.answer.linkId].answer = values.answer.answer
+			}
 		}
 
 		// updates the questionnaireItemMap to reflect the state of the questionnaire
@@ -406,6 +418,12 @@ const traverseItem = (item, questionnaireItemMap) => {
 		type: item.type || 'ignore',
 		required: item.required || false
 	}
+
+	// adds another answer object in case  we have an open-choice
+	if(item.type === 'open-choice' && !questionnaireItemMap[item.linkId].answerOption.some(e => e.isOpenQuestionAnswer)) {
+		questionnaireItemMap[item.linkId].answerOption.push({isOpenQuestionAnswer:true, answer: null})
+	}
+
 	// sets the started value to false if the item is category
 	if(item.linkId.length === 1) {
 		questionnaireItemMap[item.linkId].started = false

--- a/src/screens/checkIn/surveyScreen.js
+++ b/src/screens/checkIn/surveyScreen.js
@@ -72,6 +72,18 @@ class SurveyScreen extends Component {
 									</TouchableOpacity>)
 								}
 							</View>
+
+
+
+							<TouchableOpacity
+								accessibilityLabel={config.text.survey.send}
+								accessibilityRole={config.text.accessibility.types.button}
+								accessibilityHint={config.text.accessibility.questionnaire.sendHint}
+								onPress={() => this.props.exportAndUploadQuestionnaireResponse()}
+								style={{...localStyle.button, ...localStyle.buttonComplete}}
+							>
+								<Text style={localStyle.buttonLabel}>{config.text.survey.send}</Text>
+							</TouchableOpacity>
 						</View>
 					}
 				/>
@@ -160,6 +172,8 @@ class SurveyScreen extends Component {
 							)}
 						</ListItem>
 					))}
+
+					
 				</View>
 			)
 		return <View></View>

--- a/src/screens/checkIn/surveyScreen.js
+++ b/src/screens/checkIn/surveyScreen.js
@@ -72,18 +72,6 @@ class SurveyScreen extends Component {
 									</TouchableOpacity>)
 								}
 							</View>
-
-
-
-							<TouchableOpacity
-								accessibilityLabel={config.text.survey.send}
-								accessibilityRole={config.text.accessibility.types.button}
-								accessibilityHint={config.text.accessibility.questionnaire.sendHint}
-								onPress={() => this.props.exportAndUploadQuestionnaireResponse()}
-								style={{...localStyle.button, ...localStyle.buttonComplete}}
-							>
-								<Text style={localStyle.buttonLabel}>{config.text.survey.send}</Text>
-							</TouchableOpacity>
 						</View>
 					}
 				/>

--- a/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
+++ b/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
@@ -338,7 +338,7 @@ const checkCompletionStateOfMultipleItems = (items, props) => {
 			}
 
 			// should the item be of type "choice"...
-			if (returnValue && item.type === 'choice') {
+			if (returnValue && (item.type === 'choice' || item.type === 'open-choice')) {
 
 				// ... and only accept a single answer
 				if(!item.repeats) {
@@ -347,16 +347,12 @@ const checkCompletionStateOfMultipleItems = (items, props) => {
 				}
 				// if multiple answers are allowed
 				else {
-					// make sure there is something
-					returnValue = Array.isArray(questionnaireItemMap[item.linkId].answer) && questionnaireItemMap[item.linkId].answer.length
+					// make sure there is something							
+					let isArray = (Array.isArray(questionnaireItemMap[item.linkId].answer) && questionnaireItemMap[item.linkId].answer.length )
+					let hasAdditionalAnswer = item.type === 'open-choice' && questionnaireItemMap[item.linkId].answerOption.filter(e => e.isOpenQuestionAnswer)[0].answer
+					returnValue = isArray || hasAdditionalAnswer
 				}
 			}
-
-			// should the item be of type "open-choice"...
-			// if (returnValue && item.type === 'open-choice') {
-			// 	// ... make sure its not NULL and not empty
-			// 	returnValue = !(getCorrectlyFormattedAnswer(questionnaireItemMap[item.linkId]) === null || !questionnaireItemMap[item.linkId].answer.length)
-			// }
 		}
 		
 		// sets the done property of the item
@@ -575,6 +571,7 @@ const createResponseJSON = () => {
 							break
 
 						case 'choice':
+						case 'open-choice':
 							// if there are multiple answers
 							if (Array.isArray(itemDetails.answer)) {
 								// iterates over all answers
@@ -587,6 +584,12 @@ const createResponseJSON = () => {
 									if (childItems.length !== 0) answerObject.item = childItems
 									newItem.answer.push(answerObject)
 								})
+
+								// should the type be open-choice and an extra answer is possible
+								if(itemDetails.type === 'open-choice') {
+									let additionalAnswer = itemDetails.answerOption.filter(e => e.isOpenQuestionAnswer)[0]
+									if(additionalAnswer.answer) newItem.answer.push(createAnswerObject(additionalAnswer.answer))
+								}
 							}
 							// if there is just a single answer
 							else {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -4,6 +4,7 @@
  * these are items coming from the questionnaire that is procured from the backend.
  * @typedef {Object} QuestionnaireItem
  * @property {string} 		       text the text-item to be displayed
+ * @property {boolen} 		       repeats decides if more than one answer is allowed
  * @property {string} 		       type type if the item ("ignore" || "display" || "boolean" || "date" || "string" || "integer" || "decimal" || "number" || "choice" || "open-choice")
  * @property {string} 		       linkId id of the item
  * @property {boolean} 		       [required] if true: item needs to be answered to complete the questionnaire


### PR DESCRIPTION
This is an update in response to #23.
The `repeats` property should be supported now by choice-elements as well as open-choice-elements. The latter now comes with its own additional text-input element.