### PR TITLE
Update to enable the end of studies

### DIFF
--- a/src/components/checkIn/checkInListView.js
+++ b/src/components/checkIn/checkInListView.js
@@ -29,6 +29,7 @@ class CheckInListView extends Component {
     * @param  {object}      props.questionnaireItemMap object holding every item from the questionnaire
         (the linkId of the item is the key)
     * @param  {boolean}     props.firstTime true if the user never sent out the first 
+    * @param  {boolean}     props.lastTime true if the user received the last questionnaire
     * @param  {boolean}     props.noNewQuestionnaireAvailableYet true if there is currently no questionnaire available
     * @param  {boolean}     props.categoriesLoaded true if the questionnaire is ready to be rendered
     * @param  {Function}    props.formatDateString formats a date string
@@ -42,104 +43,106 @@ class CheckInListView extends Component {
 
     render() {
         return (
-            <View style={localStyle.wrapper}>
-                {/* if all categories are loaded AND there is a current questionnaire available render a single ListLink*/}
-                {
-                    (this.props.categoriesLoaded && !this.props.noNewQuestionnaireAvailableYet )
-                    && 
-                    (<ListItem 
-                        containerStyle={{
-                            ...localStyle.containerStyle,
-                            // if the questionnaire is partially filled out render in yellow
-                            ...(this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done && this.props.questionnaireItemMap.started ? localStyle.containerTouched :
-                                    // if the questionnaire is untouched render in red
-                                    !this.props.questionnaireItemMap.done && !this.props.questionnaireItemMap.started ? localStyle.containerUntouched :
-                                        // if the questionnaire is completed render in green
-                                        localStyle.containerCompleted )
-                        }}
-                        onPress={() => this.props.navigation.navigate('Survey')}
-                        accessibilityLabel={(this.props.firstTime ? config.text.survey.surveyTitleFirstTime : config.text.survey.surveyTitle) + ". " + (config.text.survey.surveySubTitle + this.props.formatDateString(new Date(this.props.user.due_date)))}
-                        accessibilityRole={config.text.accessibility.types.button}
-                        accessibilityHint={config.text.accessibility.questionnaire.questionnaireCellHint + 
-                            ((this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done && this.props.questionnaireItemMap.started) 
-                            ? config.text.accessibility.questionnaire.questionnaire + config.text.accessibility.questionnaire.notFinished 
-                            : (!this.props.questionnaireItemMap.done && !this.props.questionnaireItemMap.started)
-                                ? config.text.accessibility.questionnaire.questionnaire + config.text.accessibility.questionnaire.notStarted 
-                                : (this.props.questionnaireItemMap && this.props.questionnaireItemMap.done)
-                                    ? config.text.accessibility.questionnaire.questionnaire + config.text.accessibility.questionnaire.finished 
-                                    : "")}
-                    >
-                        <ListItem.Content>
-                            {/* shows a special title for first-time-users or the regular title for all other users */}
-                            <ListItem.Title style={localStyle.title}>
-                                {this.props.firstTime ? config.text.survey.surveyTitleFirstTime : config.text.survey.surveyTitle}
-                            </ListItem.Title>
-    
-                            {/* subtitle with formatted due date of the questionnaire */}
-                            <ListItem.Subtitle style={localStyle.subTitle} >
-                                {config.text.survey.surveySubTitle + this.props.formatDateString(new Date(this.props.user.due_date))}
-                            </ListItem.Subtitle>
-                        </ListItem.Content>
-    
-                        {/* renders the yellow icon if the questionnaire is partially completed */}
-                        {
-                            this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done && this.props.questionnaireItemMap.started && 
-                            (<ListItem.Chevron
-                                {
-                                    ...{
-                                        type: 'material-community',
-                                        name: 'dots-horizontal',
-                                        color: config.theme.colors.secondary,
-                                        size: 12,
-                                        raised: true,
-                                        containerStyle: {
-                                            backgroundColor: config.theme.colors.white
+            !this.props.lastTime ?
+                <View style={localStyle.wrapper}>
+                    {/* if all categories are loaded AND there is a current questionnaire available render a single ListLink*/}
+                    {
+                        (this.props.categoriesLoaded && !this.props.noNewQuestionnaireAvailableYet )
+                        && 
+                        (<ListItem 
+                            containerStyle={{
+                                ...localStyle.containerStyle,
+                                // if the questionnaire is partially filled out render in yellow
+                                ...(this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done && this.props.questionnaireItemMap.started ? localStyle.containerTouched :
+                                        // if the questionnaire is untouched render in red
+                                        !this.props.questionnaireItemMap.done && !this.props.questionnaireItemMap.started ? localStyle.containerUntouched :
+                                            // if the questionnaire is completed render in green
+                                            localStyle.containerCompleted )
+                            }}
+                            onPress={() => this.props.navigation.navigate('Survey')}
+                            accessibilityLabel={(this.props.firstTime ? config.text.survey.surveyTitleFirstTime : config.text.survey.surveyTitle) + ". " + (config.text.survey.surveySubTitle + this.props.formatDateString(new Date(this.props.user.due_date)))}
+                            accessibilityRole={config.text.accessibility.types.button}
+                            accessibilityHint={config.text.accessibility.questionnaire.questionnaireCellHint + 
+                                ((this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done && this.props.questionnaireItemMap.started) 
+                                ? config.text.accessibility.questionnaire.questionnaire + config.text.accessibility.questionnaire.notFinished 
+                                : (!this.props.questionnaireItemMap.done && !this.props.questionnaireItemMap.started)
+                                    ? config.text.accessibility.questionnaire.questionnaire + config.text.accessibility.questionnaire.notStarted 
+                                    : (this.props.questionnaireItemMap && this.props.questionnaireItemMap.done)
+                                        ? config.text.accessibility.questionnaire.questionnaire + config.text.accessibility.questionnaire.finished 
+                                        : "")}
+                        >
+                            <ListItem.Content>
+                                {/* shows a special title for first-time-users or the regular title for all other users */}
+                                <ListItem.Title style={localStyle.title}>
+                                    {this.props.firstTime ? config.text.survey.surveyTitleFirstTime : config.text.survey.surveyTitle}
+                                </ListItem.Title>
+        
+                                {/* subtitle with formatted due date of the questionnaire */}
+                                <ListItem.Subtitle style={localStyle.subTitle} >
+                                    {config.text.survey.surveySubTitle + this.props.formatDateString(new Date(this.props.user.due_date))}
+                                </ListItem.Subtitle>
+                            </ListItem.Content>
+        
+                            {/* renders the yellow icon if the questionnaire is partially completed */}
+                            {
+                                this.props.questionnaireItemMap && !this.props.questionnaireItemMap.done && this.props.questionnaireItemMap.started && 
+                                (<ListItem.Chevron
+                                    {
+                                        ...{
+                                            type: 'material-community',
+                                            name: 'dots-horizontal',
+                                            color: config.theme.colors.secondary,
+                                            size: 12,
+                                            raised: true,
+                                            containerStyle: {
+                                                backgroundColor: config.theme.colors.white
+                                            }
                                         }
                                     }
-                                }
-                            />
-                        )}
-    
-                        {/* renders the red icon if the questionnaire is untouched */}
-                        {!this.props.questionnaireItemMap.done &&
-                            !this.props.questionnaireItemMap.started && 
-                            (<ListItem.Chevron
-                                {
-                                    ...{
-                                        type: 'material-community',
-                                        name: 'pencil-outline',
-                                        color: config.theme.colors.alert,
-                                        size: 12,
-                                        raised: true,
-                                        containerStyle: {
-                                            backgroundColor: config.theme.colors.white
+                                />
+                            )}
+        
+                            {/* renders the red icon if the questionnaire is untouched */}
+                            {!this.props.questionnaireItemMap.done &&
+                                !this.props.questionnaireItemMap.started && 
+                                (<ListItem.Chevron
+                                    {
+                                        ...{
+                                            type: 'material-community',
+                                            name: 'pencil-outline',
+                                            color: config.theme.colors.alert,
+                                            size: 12,
+                                            raised: true,
+                                            containerStyle: {
+                                                backgroundColor: config.theme.colors.white
+                                            }
                                         }
                                     }
-                                }
-                            />
-                        )}
-    
-                        {/* renders the green icon if the questionnaire is completed */}
-                        {this.props.questionnaireItemMap && 
-                            this.props.questionnaireItemMap.done && 
-                            (<ListItem.Chevron
-                                {
-                                    ...{
-                                        type: 'material-community',
-                                        name: 'check',
-                                        color: config.theme.colors.success,
-                                        size: 12,
-                                        raised: true,
-                                        containerStyle: {
-                                            backgroundColor: config.theme.colors.white
+                                />
+                            )}
+        
+                            {/* renders the green icon if the questionnaire is completed */}
+                            {this.props.questionnaireItemMap && 
+                                this.props.questionnaireItemMap.done && 
+                                (<ListItem.Chevron
+                                    {
+                                        ...{
+                                            type: 'material-community',
+                                            name: 'check',
+                                            color: config.theme.colors.success,
+                                            size: 12,
+                                            raised: true,
+                                            containerStyle: {
+                                                backgroundColor: config.theme.colors.white
+                                            }
                                         }
                                     }
-                                }
-                            />
-                        )}
-                    </ListItem>)
-                }
-            </View>
+                                />
+                            )}
+                        </ListItem>)
+                    }
+                </View>
+            :<View></View>
         )
     }
 }

--- a/src/components/checkIn/checkInTiles.js
+++ b/src/components/checkIn/checkInTiles.js
@@ -24,6 +24,7 @@ class CheckInTiles extends Component {
     * @param  {object}      props
     * @param  {object}      props.user holds the userdata
     * @param  {boolean}     props.loading true if the questionnaire is still loading
+    * @param  {boolean}     props.lastTime true if the user received the last questionnaire
     * @param  {Function}    props.sendReport function to send out an report
     * @param  {boolean}     props.categoriesLoaded true if the questionnaire is ready to be rendered
     * @param  {object}      props.questionnaireItemMap object holding every item from the questionnaire (the linkId of the item is the key)
@@ -39,57 +40,59 @@ class CheckInTiles extends Component {
 
     render() {
         return (
-            <View style={localStyle.tileWrapper}>
-                <View style={localStyle.tileContainer}>
-                    {/* if there is a completed questionnaire render the button to transmit the it*/}
-                    {
-                        (!this.props.noNewQuestionnaireAvailableYet && this.props.categoriesLoaded && !this.props.loading && this.props.questionnaireItemMap.done) 
-                        &&
-                        (<View>
-                            <TouchableOpacity
-                                style={{...localStyle.tile, ...localStyle.buttonGreen}}
-                                disabled={this.props.user && this.props.noNewQuestionnaireAvailableYet}
-                                onPress={this.props.exportAndUploadQuestionnaireResponse}
-                                accessibilityLabel={config.text.survey.send}
-                                accessibilityRole={config.text.accessibility.types.button}
-                                accessibilityHint={config.text.accessibility.questionnaire.sendHint}
-                            >
-                                <View style={localStyle.buttonWrapper}>
-                                    <Icon
-                                        name='school'
-                                        color={config.theme.colors.white}
-                                        iconStyle={localStyle.buttonIcon}
-                                    />
-                                        
-                                    <Text style={localStyle.tileText}>
-                                        {config.text.survey.send}
-                                    </Text>
-                                </View>
-                            </TouchableOpacity>
-                        </View>)
-                    }
-    
-                    {/* the 'send report' button */}
-                    <TouchableOpacity
-                        onPress={this.props.sendReport}
-                        // renders the button in grey if there is no questionnaire available 
-                        // or if the user already send out a report and is still on a special interval (additional_iterations_left will be greater than 0 if thats the case)
-                        style={(this.props.noNewQuestionnaireAvailableYet || (this.props.user && this.props.user.additional_iterations_left > 0)) ? localStyle.tile : localStyle.disabledTile}
-                        accessibilityRole={config.text.accessibility.types.button}
-                    >
-                        <View style={localStyle.buttonWrapper}>
-                            <Icon
-                                name='error'
-                                color={config.theme.colors.white}
-                                iconStyle={localStyle.buttonIcon}
-                            />
-                            <Text style={localStyle.tileText}>
-                                {config.text.reporting.symptoms_header}
-                            </Text>
-                        </View>
-                    </TouchableOpacity>
+            !this.props.lastTime ?
+                <View style={localStyle.tileWrapper}>
+                    <View style={localStyle.tileContainer}>
+                        {/* if there is a completed questionnaire render the button to transmit the it*/}
+                        {
+                            (!this.props.noNewQuestionnaireAvailableYet && this.props.categoriesLoaded && !this.props.loading && this.props.questionnaireItemMap.done) 
+                            &&
+                            (<View>
+                                <TouchableOpacity
+                                    style={{...localStyle.tile, ...localStyle.buttonGreen}}
+                                    disabled={this.props.user && this.props.noNewQuestionnaireAvailableYet}
+                                    onPress={this.props.exportAndUploadQuestionnaireResponse}
+                                    accessibilityLabel={config.text.survey.send}
+                                    accessibilityRole={config.text.accessibility.types.button}
+                                    accessibilityHint={config.text.accessibility.questionnaire.sendHint}
+                                >
+                                    <View style={localStyle.buttonWrapper}>
+                                        <Icon
+                                            name='school'
+                                            color={config.theme.colors.white}
+                                            iconStyle={localStyle.buttonIcon}
+                                        />
+                                            
+                                        <Text style={localStyle.tileText}>
+                                            {config.text.survey.send}
+                                        </Text>
+                                    </View>
+                                </TouchableOpacity>
+                            </View>)
+                        }
+        
+                        {/* the 'send report' button */}
+                        <TouchableOpacity
+                            onPress={this.props.sendReport}
+                            // renders the button in grey if there is no questionnaire available 
+                            // or if the user already send out a report and is still on a special interval (additional_iterations_left will be greater than 0 if thats the case)
+                            style={(this.props.noNewQuestionnaireAvailableYet || (this.props.user && this.props.user.additional_iterations_left > 0)) ? localStyle.tile : localStyle.disabledTile}
+                            accessibilityRole={config.text.accessibility.types.button}
+                        >
+                            <View style={localStyle.buttonWrapper}>
+                                <Icon
+                                    name='error'
+                                    color={config.theme.colors.white}
+                                    iconStyle={localStyle.buttonIcon}
+                                />
+                                <Text style={localStyle.tileText}>
+                                    {config.text.reporting.symptoms_header}
+                                </Text>
+                            </View>
+                        </TouchableOpacity>
+                    </View>
                 </View>
-            </View>
+            :<View></View>
         )
     }
 }

--- a/src/components/checkIn/welcomeText.js
+++ b/src/components/checkIn/welcomeText.js
@@ -27,6 +27,7 @@ class WelcomeText extends Component {
 	* @param  {object}      props.questionnaireError the return object should the sendQuestionnaire 
 		function produce an error
 	* @param  {boolean}     props.firstTime true if the user never sent out the first questionnaire
+	* @param  {boolean}     props.lastTime true if the user received the last questionnaire
 	* @param  {boolean}     props.error401 true if the user was rejected by the backend
 	* @param  {boolean}     props.noNewQuestionnaireAvailableYet true if there is currently no 
 		questionnaire available
@@ -51,68 +52,84 @@ class WelcomeText extends Component {
 						<Text style={localStyle.welcomeText}> 
 							{ this.props.firstTime ? 
 								config.text.survey.welcomeTitleFirstTime : 
-									this.props.noNewQuestionnaireAvailableYet ?
-										config.text.survey.noNewQuestionnaireAvailableYetTitle :
-											config.text.survey.welcomeTitle }
+									this.props.lastTime ?
+										config.text.survey.lastTimeTitle :
+											this.props.noNewQuestionnaireAvailableYet ?
+												config.text.survey.noNewQuestionnaireAvailableYetTitle :
+													config.text.survey.welcomeTitle }
 						</Text>
-	
-						{/* if this is a new user */}
-						{this.props.firstTime && this.props.user && (
-							<Text  style={localStyle.infoText}>
-								{config.text.survey.welcomeTextFirstTimeUser1}
-								<Text style={{...localStyle.timeTextSmall}}>
-									{ this.props.formatDateString(this.props.user.due_date, true) }.
+
+						{/* if the study is still running */}
+						{!this.props.lastTime && (
+							<View>
+								{/* if this is a new user */}
+								{this.props.firstTime && this.props.user && (
+									<Text  style={localStyle.infoText}>
+										{config.text.survey.welcomeTextFirstTimeUser1}
+										<Text style={{...localStyle.timeTextSmall}}>
+											{ this.props.formatDateString(this.props.user.due_date, true) }.
+										</Text>
+										{config.text.survey.welcomeTextFirstTimeUser2}
+									</Text>
+								)}
+			
+								{/* if this is not a first-time-user and NO new questionnaire is currently available */}
+								{!this.props.firstTime && this.props.noNewQuestionnaireAvailableYet && (
+									<Text style={localStyle.infoText}>
+										{config.text.survey.noNewQuestionnaireAvailableYet}
+									</Text>
+								)}
+			
+								{/* if this is not a first-time-user and A questionnaire is currently available */}
+								{!this.props.firstTime && !this.props.noNewQuestionnaireAvailableYet && (
+									<View>
+										<Text style={localStyle.infoText}>
+											{config.text.survey.welcomeTextUser}
+										</Text>
+										<Text style={{...localStyle.timeText}}>
+											{ this.props.formatDateString(this.props.user.due_date, true) }.
+										</Text>
+									</View>
+								)}
+			
+								{/* if this is not a first-time-user and NO new questionnaire is currently available */}
+								{!this.props.firstTime && this.props.noNewQuestionnaireAvailableYet && (
+									<View>
+										<Text style={localStyle.timeText}>
+											{config.text.survey.nextOne}
+										</Text>
+										<Text style={{...localStyle.timeText, ...localStyle.timeTextGreen}}>
+											{ this.props.formatDateString(this.props.user.start_date, true) }.
+										</Text>
+									</View>
+								)}
+			
+								{/* if this is a first-time-user and A questionnaire is currently available */}
+								{this.props.firstTime && this.props.noNewQuestionnaireAvailableYet &&(
+									<View>
+										<Text style={localStyle.timeText}>
+											{config.text.survey.nextOneNew}
+										</Text>
+										<Text style={{...localStyle.timeText, ...localStyle.timeTextGreen}}>
+											{ this.props.formatDateString(this.props.user.start_date, true) }.
+										</Text>
+									</View>
+								)}
+			
+								<Text style={localStyle.infoText}>
+									{config.text.survey.furtherInfo}
 								</Text>
-								{config.text.survey.welcomeTextFirstTimeUser2}
-							</Text>
+							</View>
 						)}
-	
-						{/* if this is not a first-time-user and NO new questionnaire is currently available */}
-						{!this.props.firstTime && this.props.noNewQuestionnaireAvailableYet && (
-							<Text style={localStyle.infoText}>
-								{config.text.survey.noNewQuestionnaireAvailableYet}
-							</Text>
-						)}
-	
-						{/* if this is not a first-time-user and A questionnaire is currently available */}
-						{!this.props.firstTime && !this.props.noNewQuestionnaireAvailableYet && (
+
+						{/* if the study was ended */}
+						{this.props.lastTime && (
 							<View>
 								<Text style={localStyle.infoText}>
-									{config.text.survey.welcomeTextUser}
-								</Text>
-								<Text style={{...localStyle.timeText}}>
-									{ this.props.formatDateString(this.props.user.due_date, true) }.
-								</Text>
+									{config.text.survey.lastTime}
+								</Text>	
 							</View>
 						)}
-	
-						{/* if this is not a first-time-user and NO new questionnaire is currently available */}
-						{!this.props.firstTime && this.props.noNewQuestionnaireAvailableYet && (
-							<View>
-								<Text style={localStyle.timeText}>
-									{config.text.survey.nextOne}
-								</Text>
-								<Text style={{...localStyle.timeText, ...localStyle.timeTextGreen}}>
-									{ this.props.formatDateString(this.props.user.start_date, true) }.
-								</Text>
-							</View>
-						)}
-	
-						{/* if this is a first-time-user and A questionnaire is currently available */}
-						{this.props.firstTime && this.props.noNewQuestionnaireAvailableYet &&(
-							<View>
-								<Text style={localStyle.timeText}>
-									{config.text.survey.nextOneNew}
-								</Text>
-								<Text style={{...localStyle.timeText, ...localStyle.timeTextGreen}}>
-									{ this.props.formatDateString(this.props.user.start_date, true) }.
-								</Text>
-							</View>
-						)}
-	
-						<Text style={localStyle.infoText}>
-							{config.text.survey.furtherInfo}
-						</Text>
 					</View>)
 				}
 	

--- a/src/config/textConfig.js
+++ b/src/config/textConfig.js
@@ -197,6 +197,8 @@ export default {
 		"noUserText":"Your ID could not be verified. Please try again.",
 		"noNewQuestionnaireAvailableYetTitle":"Title, in case no Questionnaire is available",
 		"sendFinishedMessage":"confirmation dialog for sending the completed questionnaire?",
+		"lastTime":"Text telling the user that the study has concluded.",
+		"lastTimeTitle":"Title of the final message",
 		"sendUnfinishedMessageDenied":"The current questionnaire is not yet completed. Please do so.",
 		"nextOne":"This text will be shown to communicate when the next questionnaire is available: ",
 		"noQuestionnaireText":"There occurred an error while loading the questionnaire - Please try again.",

--- a/src/screens/checkIn/checkInContainer.js
+++ b/src/screens/checkIn/checkInContainer.js
@@ -147,6 +147,9 @@ class CheckInContainer extends Component {
 	 * tries to procure the current questionnaire
 	 */
 	getQuestionnaire = async () => {
+
+		if(!this.props.user.current_questionnaire_id || this.props.user.lastTime) return true
+
 		// redux output
 		this.props.actions.getQuestionnaireStart()
 		

--- a/src/screens/checkIn/checkInReducer.js
+++ b/src/screens/checkIn/checkInReducer.js
@@ -15,6 +15,7 @@ const initialState = {
 	loading: false,
 	error401: false,
 	firstTime: true,
+	lastTime: false,
 	categories: null,
 	currentPageIndex: 1,
 	showDatePicker: false,
@@ -332,6 +333,7 @@ const valuesHandlers = {
 			loading: false,
 			user: values.user,
 			firstTime: values.user.firstTime,
+			lastTime: values.user.lastTime,
 			questionnaireError: null,
 			noNewQuestionnaireAvailableYet: new Date() < new Date(values.user.start_date),
 		}


### PR DESCRIPTION
This updates the templates to recognize an additional attribute in the user-object: `lastTime`.
The idea is that the backend will provide an additional check to determine if the study is still running - and if not, adds an attribute to the user-object so that the frontend can display an appropriate message. Something like "_The study has ended._". The string can - as always - be found the file textConfig.js.

If there is no such attribute in the user-object then everything works like nothing was changed.
This additional logic-check still needs to be implemented in the backend - so this PR is still a draft until that time.

Also, we still don't know if `lastTime` is an appropriate name for that attribute