### PR TITLE
Validation Check Fix

### DIFF
--- a/src/components/modal/questionnaireModal.jsx
+++ b/src/components/modal/questionnaireModal.jsx
@@ -757,11 +757,10 @@ class QuestionnaireModal extends Component {
       <View style={localStyle.modalInput}>
         {/* title */}
         <Text style={{ ...localStyle.contentTitle }}>{item.text}</Text>
-
         {/* input */}
         <Input
           placeholder={config.text.login.inputPlaceholder}
-          value={questionnaireItemMap[item.linkId].answer}
+          value={questionnaireItemMap[item.linkId].answer || ''} // displays an empty string when a 'falsy' answer needs to be rendered
           keyboardType={this.getKeyboardType(item)}
           maxLength={item.maxLength || null}
           // accessibilityLabel={ }
@@ -769,7 +768,8 @@ class QuestionnaireModal extends Component {
             config.text.accessibility.questionnaire.textFieldHint
           }
           onChangeText={(text) => {
-            let retVal;
+            // holds the initial, unedited text - in case that no manipulation is needed
+            let retVal = text;
             // filters anything that is not a number
             if (item.type === "integer") {
               retVal = text
@@ -787,7 +787,7 @@ class QuestionnaireModal extends Component {
 
               const split = retVal.split(".");
               if (split.length - 1 > 1) retVal = `${split[0]}.${split[1]}`;
-              if (retVal === ".") retVal = "";
+              if (retVal === ".") retVal = null;
             }
             // sets the answer
             actions.setAnswer({


### PR DESCRIPTION
This PR addresses the issue #48.

It slightly adjusts the function `onChangeText()` provided by the input element that is generated by `createInput()` (provided by `questionnaireModal.js`)

The following issues have been resolved:
1. The original, unedited value was not persisted if no string-manipulation occurred.
2. The string correction for inputs of type `integer` and `number` could not replace a given value with null and update the rendering input accordingly.