### PR TITLE
move method in utils module

### DIFF
--- a/src/components/checkIn/checkInListView.jsx
+++ b/src/components/checkIn/checkInListView.jsx
@@ -9,6 +9,7 @@ import { View, StyleSheet } from "react-native";
 import { ListItem } from "react-native-elements";
 
 import config from "../../config/configProvider";
+import { formatDateString } from "../../services/utils";
 
 let localStyle;
 
@@ -31,7 +32,6 @@ class CheckInListView extends PureComponent {
     * @param  {boolean}     props.firstTime true if the user never sent out the first 
     * @param  {boolean}     props.noNewQuestionnaireAvailableYet true if there is currently no questionnaire available
     * @param  {boolean}     props.categoriesLoaded true if the questionnaire is ready to be rendered
-    * @param  {Function}    props.formatDateString formats a date string
     */
 
   /**
@@ -116,59 +116,57 @@ class CheckInListView extends PureComponent {
       categoriesLoaded,
       noNewQuestionnaireAvailableYet,
       navigation,
-      formatDateString,
       user,
     } = this.props;
     return (
       <View style={localStyle.wrapper}>
         {/* if all categories are loaded AND there is a current questionnaire available render a single ListLink AND if the user ist still part of the study*/}
-        {categoriesLoaded && 
-        !noNewQuestionnaireAvailableYet && 
-        user?.status !== 'off-study' && 
-        (
-          <ListItem
-            containerStyle={{
-              ...localStyle.containerStyle,
-              // get additional styling depending on the state of the questionnaire
-              ...this.getListItemStyle(),
-            }}
-            onPress={() => navigation.navigate("Survey")}
-            accessibilityLabel={`${
-              user.firstTime
-                ? config.text.survey.surveyTitleFirstTime
-                : config.text.survey.surveyTitle
-            }. ${
-              config.text.survey.surveySubTitle +
-              formatDateString(new Date(user.due_date))
-            }`}
-            accessibilityRole={config.text.accessibility.types.button}
-            accessibilityHint={this.getAccessibilityHint()}
-          >
-            <ListItem.Content>
-              {/* shows a special title for first-time-users or the regular title for all other users */}
-              <ListItem.Title style={localStyle.title}>
-                {user.firstTime
+        {categoriesLoaded &&
+          !noNewQuestionnaireAvailableYet &&
+          user?.status !== "off-study" && (
+            <ListItem
+              containerStyle={{
+                ...localStyle.containerStyle,
+                // get additional styling depending on the state of the questionnaire
+                ...this.getListItemStyle(),
+              }}
+              onPress={() => navigation.navigate("Survey")}
+              accessibilityLabel={`${
+                user.firstTime
                   ? config.text.survey.surveyTitleFirstTime
-                  : config.text.survey.surveyTitle}
-              </ListItem.Title>
+                  : config.text.survey.surveyTitle
+              }. ${
+                config.text.survey.surveySubTitle +
+                formatDateString(new Date(user.due_date))
+              }`}
+              accessibilityRole={config.text.accessibility.types.button}
+              accessibilityHint={this.getAccessibilityHint()}
+            >
+              <ListItem.Content>
+                {/* shows a special title for first-time-users or the regular title for all other users */}
+                <ListItem.Title style={localStyle.title}>
+                  {user.firstTime
+                    ? config.text.survey.surveyTitleFirstTime
+                    : config.text.survey.surveyTitle}
+                </ListItem.Title>
 
-              {/* subtitle with formatted due date of the questionnaire */}
-              <ListItem.Subtitle style={localStyle.subTitle}>
-                {config.text.survey.surveySubTitle +
-                  formatDateString(new Date(user.due_date))}
-              </ListItem.Subtitle>
-            </ListItem.Content>
-            {/* renders icon */}
-            <ListItem.Chevron
-              type="material-community"
-              size={12}
-              raised
-              containerStyle={{ backgroundColor: config.theme.colors.white }}
-              // get additional properties based on the state of the questionnaire
-              iconProps={this.getChevronProps()}
-            />
-          </ListItem>
-        )}
+                {/* subtitle with formatted due date of the questionnaire */}
+                <ListItem.Subtitle style={localStyle.subTitle}>
+                  {config.text.survey.surveySubTitle +
+                    formatDateString(new Date(user.due_date))}
+                </ListItem.Subtitle>
+              </ListItem.Content>
+              {/* renders icon */}
+              <ListItem.Chevron
+                type="material-community"
+                size={12}
+                raised
+                containerStyle={{ backgroundColor: config.theme.colors.white }}
+                // get additional properties based on the state of the questionnaire
+                iconProps={this.getChevronProps()}
+              />
+            </ListItem>
+          )}
       </View>
     );
   }

--- a/src/components/checkIn/welcomeText.jsx
+++ b/src/components/checkIn/welcomeText.jsx
@@ -8,6 +8,7 @@ import React, { PureComponent } from "react";
 import { Text, View, StyleSheet } from "react-native";
 
 import config from "../../config/configProvider";
+import { formatDateString } from "../../services/utils";
 
 let localStyle;
 
@@ -29,7 +30,6 @@ class WelcomeText extends PureComponent {
 	* @param  {boolean}     props.error401 true if the user was rejected by the backend
 	* @param  {boolean}     props.noNewQuestionnaireAvailableYet true if there is currently no 
 		questionnaire available
-	* @param  {Function}    props.formatDateString formats a date string
 	*/
 
   // rendering
@@ -40,96 +40,97 @@ class WelcomeText extends PureComponent {
       error401,
       questionnaireError,
       noNewQuestionnaireAvailableYet,
-      formatDateString,
       user,
     } = this.props;
     return (
       <View style={localStyle.wrapper}>
         {/* if there is no authentication error, no sending error and the participant ist still part of the study */}
-        {!error401 && questionnaireError === null && user?.status !== 'off-study' && (
-          <View>
-            {/* title text: depends on the params 'firstTime' & 'noNewQuestionnaireAvailableYet'*/}
-            <Text style={localStyle.welcomeText}>
-              {(() => {
-                if (user.firstTime)
-                  return config.text.survey.welcomeTitleFirstTime;
-                if (noNewQuestionnaireAvailableYet)
-                  return config.text.survey.noNewQuestionnaireAvailableYet;
-                return config.text.survey.welcomeTitle;
-              })()}
-            </Text>
-
-            {/* if this is a new user */}
-            {user.firstTime && user && (
-              <Text style={localStyle.infoText}>
-                {config.text.survey.welcomeTextFirstTimeUser1}
-                <Text style={{ ...localStyle.timeTextSmall }}>
-                  {formatDateString(user.due_date, true)}.
-                </Text>
-                {config.text.survey.welcomeTextFirstTimeUser2}
+        {!error401 &&
+          questionnaireError === null &&
+          user?.status !== "off-study" && (
+            <View>
+              {/* title text: depends on the params 'firstTime' & 'noNewQuestionnaireAvailableYet'*/}
+              <Text style={localStyle.welcomeText}>
+                {(() => {
+                  if (user.firstTime)
+                    return config.text.survey.welcomeTitleFirstTime;
+                  if (noNewQuestionnaireAvailableYet)
+                    return config.text.survey.noNewQuestionnaireAvailableYet;
+                  return config.text.survey.welcomeTitle;
+                })()}
               </Text>
-            )}
 
-            {/* if this is not a first-time-user and NO new questionnaire is currently available */}
-            {!user.firstTime && noNewQuestionnaireAvailableYet && (
-              <Text style={localStyle.infoText}>
-                {config.text.survey.noNewQuestionnaireAvailableYet}
-              </Text>
-            )}
-
-            {/* if this is not a first-time-user and A questionnaire is currently available */}
-            {!user.firstTime && !noNewQuestionnaireAvailableYet && (
-              <View>
+              {/* if this is a new user */}
+              {user.firstTime && user && (
                 <Text style={localStyle.infoText}>
-                  {config.text.survey.welcomeTextUser}
+                  {config.text.survey.welcomeTextFirstTimeUser1}
+                  <Text style={{ ...localStyle.timeTextSmall }}>
+                    {formatDateString(user.due_date, true)}.
+                  </Text>
+                  {config.text.survey.welcomeTextFirstTimeUser2}
                 </Text>
-                <Text style={{ ...localStyle.timeText }}>
-                  {formatDateString(user.due_date, true)}.
-                </Text>
-              </View>
-            )}
+              )}
 
-            {/* if this is not a first-time-user and NO new questionnaire is currently available */}
-            {!user.firstTime && noNewQuestionnaireAvailableYet && (
-              <View>
-                <Text style={localStyle.timeText}>
-                  {config.text.survey.nextOne}
+              {/* if this is not a first-time-user and NO new questionnaire is currently available */}
+              {!user.firstTime && noNewQuestionnaireAvailableYet && (
+                <Text style={localStyle.infoText}>
+                  {config.text.survey.noNewQuestionnaireAvailableYet}
                 </Text>
-                <Text
-                  style={{
-                    ...localStyle.timeText,
-                    ...localStyle.timeTextGreen,
-                  }}
-                >
-                  {formatDateString(user.start_date, true)}.
-                </Text>
-              </View>
-            )}
+              )}
 
-            {/* if this is a first-time-user and A questionnaire is currently available */}
-            {user.firstTime && noNewQuestionnaireAvailableYet && (
-              <View>
-                <Text style={localStyle.timeText}>
-                  {config.text.survey.nextOneNew}
-                </Text>
-                <Text
-                  style={{
-                    ...localStyle.timeText,
-                    ...localStyle.timeTextGreen,
-                  }}
-                >
-                  {formatDateString(user.start_date, true)}.
-                </Text>
-              </View>
-            )}
+              {/* if this is not a first-time-user and A questionnaire is currently available */}
+              {!user.firstTime && !noNewQuestionnaireAvailableYet && (
+                <View>
+                  <Text style={localStyle.infoText}>
+                    {config.text.survey.welcomeTextUser}
+                  </Text>
+                  <Text style={{ ...localStyle.timeText }}>
+                    {formatDateString(user.due_date, true)}.
+                  </Text>
+                </View>
+              )}
 
-            <Text style={localStyle.infoText}>
-              {config.text.survey.furtherInfo}
-            </Text>
-          </View>
-        )}
+              {/* if this is not a first-time-user and NO new questionnaire is currently available */}
+              {!user.firstTime && noNewQuestionnaireAvailableYet && (
+                <View>
+                  <Text style={localStyle.timeText}>
+                    {config.text.survey.nextOne}
+                  </Text>
+                  <Text
+                    style={{
+                      ...localStyle.timeText,
+                      ...localStyle.timeTextGreen,
+                    }}
+                  >
+                    {formatDateString(user.start_date, true)}.
+                  </Text>
+                </View>
+              )}
 
-        {user?.status === 'off-study' && (
+              {/* if this is a first-time-user and A questionnaire is currently available */}
+              {user.firstTime && noNewQuestionnaireAvailableYet && (
+                <View>
+                  <Text style={localStyle.timeText}>
+                    {config.text.survey.nextOneNew}
+                  </Text>
+                  <Text
+                    style={{
+                      ...localStyle.timeText,
+                      ...localStyle.timeTextGreen,
+                    }}
+                  >
+                    {formatDateString(user.start_date, true)}.
+                  </Text>
+                </View>
+              )}
+
+              <Text style={localStyle.infoText}>
+                {config.text.survey.furtherInfo}
+              </Text>
+            </View>
+          )}
+
+        {user?.status === "off-study" && (
           <View>
             <Text style={localStyle.welcomeText}>
               {config.text.survey.endedStudyTitle}

--- a/src/screens/checkIn/checkInContainer.jsx
+++ b/src/screens/checkIn/checkInContainer.jsx
@@ -564,12 +564,11 @@ class CheckInContainer extends Component {
   // support
   /*-----------------------------------------------------------------------------------*/
 
-    /**
+  /**
    * shows a confirmation-dialog. if confirmed, it deletes the local data, logs the user
    * out and navigates back to the landing-screen.
    */
   deleteLocalDataAndLogout = () => {
-
     const { actions, navigation } = this.props;
     Alert.alert(
       config.text.generic.warning,
@@ -593,32 +592,6 @@ class CheckInContainer extends Component {
       ],
       { cancelable: false }
     );
-  };
-
-  /**
-   * generates a date string from Date Object (dd.mm.yyyy)
-   * @param  {Date}    inputDate the input date
-   * @param  {boolean} includeTime if true: the exported string will also contain the time
-   */
-  formatDateString = (inputDate, includeTime) => {
-    const date = new Date(inputDate);
-    const numericMonth = date.getMonth() + 1;
-
-    let monthString = numericMonth.toString();
-    let dayString = date.getDate().toString();
-    let hourString = date.getHours().toString();
-    let minutesString = date.getMinutes().toString();
-
-    if (dayString.length === 1) dayString = `0${dayString}`;
-    if (monthString.length === 1) monthString = `0${monthString}`;
-    if (hourString.length === 1) hourString = `0${hourString}`;
-    if (minutesString.length === 1) minutesString = `0${minutesString}`;
-
-    let dateString = `${dayString}.${monthString}.${date.getFullYear()}`;
-    if (includeTime)
-      dateString = `${dateString}, ${hourString}:${minutesString}`;
-
-    return dateString;
   };
 
   // rendering
@@ -665,7 +638,6 @@ class CheckInContainer extends Component {
         }
         sendReport={this.sendReport}
         updateUser={this.updateUser}
-        formatDateString={this.formatDateString}
       />
     ) : (
       // if on Survey route

--- a/src/screens/checkIn/checkInScreen.jsx
+++ b/src/screens/checkIn/checkInScreen.jsx
@@ -48,8 +48,7 @@ class CheckInScreen extends PureComponent {
       user,
       sendReport,
       noNewQuestionnaireAvailableYet,
-      formatDateString,
-      deleteLocalDataAndLogout
+      deleteLocalDataAndLogout,
     } = this.props;
 
     return (
@@ -65,7 +64,7 @@ class CheckInScreen extends PureComponent {
           updateUser={updateUser}
           isCheckIn
           noWayBack
-          noRefresh={user?.status==='off-study'}
+          noRefresh={user?.status === "off-study"}
           categoriesLoaded={categoriesLoaded}
         />
 
@@ -84,7 +83,6 @@ class CheckInScreen extends PureComponent {
                       user={user}
                       navigation={navigation}
                       categoriesLoaded={categoriesLoaded}
-                      formatDateString={formatDateString}
                       questionnaireItemMap={questionnaireItemMap}
                       noNewQuestionnaireAvailableYet={
                         noNewQuestionnaireAvailableYet
@@ -98,7 +96,6 @@ class CheckInScreen extends PureComponent {
                       noNewQuestionnaireAvailableYet={
                         noNewQuestionnaireAvailableYet
                       }
-                      formatDateString={formatDateString}
                       user={user}
                     />
                     {/* renders the button at the bottom */}
@@ -129,7 +126,6 @@ class CheckInScreen extends PureComponent {
                       noNewQuestionnaireAvailableYet={
                         noNewQuestionnaireAvailableYet
                       }
-                      formatDateString={formatDateString}
                     />
                   </View>
                 )}

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,0 +1,31 @@
+/**
+ * utility functions used throughout the application
+ */
+
+/**
+ * generates a date string from Date Object (dd.mm.yyyy)
+ * @param  {Date}    inputDate the input date
+ * @param  {boolean} includeTime if true: the exported string will also contain the time
+ */
+const formatDateString = (inputDate, includeTime) => {
+  const date = new Date(inputDate);
+  const numericMonth = date.getMonth() + 1;
+
+  let monthString = numericMonth.toString();
+  let dayString = date.getDate().toString();
+  let hourString = date.getHours().toString();
+  let minutesString = date.getMinutes().toString();
+
+  if (dayString.length === 1) dayString = `0${dayString}`;
+  if (monthString.length === 1) monthString = `0${monthString}`;
+  if (hourString.length === 1) hourString = `0${hourString}`;
+  if (minutesString.length === 1) minutesString = `0${minutesString}`;
+
+  let dateString = `${dayString}.${monthString}.${date.getFullYear()}`;
+  if (includeTime) dateString = `${dateString}, ${hourString}:${minutesString}`;
+
+  return dateString;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { formatDateString };


### PR DESCRIPTION
With this pull request, instead of defining it in 'checkInContainer' and then passing it down as prop, the method 'formatDateString' is moved to a newly created module named 'utils' and imported where necessary.