### PR TITLE
added error-messages to the login-screen (error-handling)

### DIFF
--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -63,12 +63,12 @@ const conf = {
 
   /** dev-option:
    * skips the QR login after 500ms */
-  automateQrLogin: __DEV__ && true,
+  automateQrLogin: __DEV__ && false,
 
   /** dev-option:
    * subject-id for automated login */
   automateQrLoginSubjectId:
-    '{"AppIdentifier":"COMPASS","SubjectId":"7bfsc3b07-a97d-4e11-8ac6-b970c1745476"}',
+    '{"AppIdentifier":"COMPASS","SubjectId":"7bfc3b07-a97d-4e11-8ac6-b970c1745476"}',
 
   /** dev-option:
    * shows a button to erase all data (in the about-menu) - dev-only */

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -63,12 +63,12 @@ const conf = {
 
   /** dev-option:
    * skips the QR login after 500ms */
-  automateQrLogin: __DEV__ && false,
+  automateQrLogin: __DEV__ && true,
 
   /** dev-option:
    * subject-id for automated login */
   automateQrLoginSubjectId:
-    '{"AppIdentifier":"COMPASS","SubjectId":"7bfc3b07-a97d-4e11-8ac6-b970c1745476"}',
+    '{"AppIdentifier":"COMPASS","SubjectId":"7bfsc3b07-a97d-4e11-8ac6-b970c1745476"}',
 
   /** dev-option:
    * shows a button to erase all data (in the about-menu) - dev-only */

--- a/src/config/textConfig.js
+++ b/src/config/textConfig.js
@@ -106,6 +106,7 @@ export default {
 		"qrInfo":"Please point the camera onto the qr-code.",
 		"errorUserGeneric":"There occurred a problem during login.",
 		"permissionDialog":"Please allow the app to access your camera.",
+		"nextStepAfterError": "Please try to login again later.",
 
 		/** contains all strings of the landing-screen */
 		"landing":{

--- a/src/screens/login/loginContainer.jsx
+++ b/src/screens/login/loginContainer.jsx
@@ -28,8 +28,8 @@ class LoginContainer extends Component {
    * @param  {object}    props.actions holds actions for the component (./loginActions.js)
    * @param  {boolean}   props.loggedIn if true: user is logged in
    * @param  {object}    props.navigation the navigation object provided by 'react-navigation'
-   * @param  {boolean}   props.loginUnauthorized the navigation object provided by 'react-navigation'
-   * @param  {object}    props.loginError the navigation object provided by 'react-navigation'
+   * @param  {boolean}   props.loginUnauthorized if true: the last authentication attempt returned a 401
+   * @param  {object}    props.loginError the persisted error of the last authentication attempt
    */
 
   // events

--- a/src/screens/login/loginContainer.jsx
+++ b/src/screens/login/loginContainer.jsx
@@ -28,6 +28,8 @@ class LoginContainer extends Component {
    * @param  {object}    props.actions holds actions for the component (./loginActions.js)
    * @param  {boolean}   props.loggedIn if true: user is logged in
    * @param  {object}    props.navigation the navigation object provided by 'react-navigation'
+   * @param  {boolean}   props.loginUnauthorized the navigation object provided by 'react-navigation'
+   * @param  {object}    props.loginError the navigation object provided by 'react-navigation'
    */
 
   // events
@@ -130,13 +132,15 @@ class LoginContainer extends Component {
   /*-----------------------------------------------------------------------------------*/
 
   render() {
-    const { loading, actions, navigation } = this.props;
+    const { loading, actions, navigation, loginUnauthorized, loginError } = this.props;
     // checks the currently selected route
     return navigation.state.routeName === "Login" ? (
       // if on Login route
       <LoginScreen
         actions={actions}
         loading={loading}
+        loginError={loginError}
+        loginUnauthorized={loginUnauthorized}
         navigation={navigation}
         scanSuccess={this.scanSuccess}
       />

--- a/src/screens/login/loginReducer.js
+++ b/src/screens/login/loginReducer.js
@@ -26,6 +26,8 @@ const actionHandlers = {
     ...state,
     loading: true,
     loggedIn: false,
+    loginError: null,
+    loginUnauthorized: false
   }),
 
   /**

--- a/src/screens/login/loginScreen.jsx
+++ b/src/screens/login/loginScreen.jsx
@@ -33,8 +33,8 @@ class LoginScreen extends Component {
    * @param  {object}    props.actions holds the actions for this state
    * @param  {object}    props.navigation the navigation object provided by 'react-navigation'
    * @param  {Function}  props.scanSuccess function that is triggered when the qr-scanner picks something up
-   * @param  {boolean}   props.loginUnauthorized the navigation object provided by 'react-navigation'
-   * @param  {object}    props.loginError the navigation object provided by 'react-navigation'
+   * @param  {boolean}   props.loginUnauthorized if true: the last authentication attempt returned a 401
+   * @param  {object}    props.loginError the persisted error of the last authentication attempt
    */
   constructor(props) {
     super(props);

--- a/src/screens/login/loginScreen.jsx
+++ b/src/screens/login/loginScreen.jsx
@@ -100,10 +100,14 @@ class LoginScreen extends Component {
 
                       {/* if anything other than a 401: outputs the returned error message (or a generic error message instead) */}
                       {!loginUnauthorized && (
-                        <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
-                          {(loginError?.message || config.text.login.errorUserGeneric) + '\n'}
-                          {config.text.login.nextStepAfterError}
-                        </Text>
+                        <View>
+                          <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
+                            {(loginError?.message || config.text.login.errorUserGeneric)}
+                          </Text>
+                          <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
+                            {config.text.login.nextStepAfterError}
+                          </Text>
+                        </View>
                       )}
                     </View>
                   )}

--- a/src/screens/login/loginScreen.jsx
+++ b/src/screens/login/loginScreen.jsx
@@ -33,6 +33,8 @@ class LoginScreen extends Component {
    * @param  {object}    props.actions holds the actions for this state
    * @param  {object}    props.navigation the navigation object provided by 'react-navigation'
    * @param  {Function}  props.scanSuccess function that is triggered when the qr-scanner picks something up
+   * @param  {boolean}   props.loginUnauthorized the navigation object provided by 'react-navigation'
+   * @param  {object}    props.loginError the navigation object provided by 'react-navigation'
    */
   constructor(props) {
     super(props);
@@ -43,7 +45,7 @@ class LoginScreen extends Component {
   /*-----------------------------------------------------------------------------------*/
 
   render() {
-    const { navigation, actions, scanSuccess } = this.props;
+    const { navigation, actions, scanSuccess, loginError, loginUnauthorized } = this.props;
     return (
       <View style={localStyle.wrapper}>
         {/* banner */}
@@ -85,6 +87,26 @@ class LoginScreen extends Component {
                   <Text style={localStyle.infoText}>
                     {config.text.login.qrInfo}
                   </Text>
+
+                  {/* login error text */}
+                  {loginError && (
+                    <View>
+                      {/* displays an error message in case of 401 */}
+                      {loginUnauthorized && (
+                        <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
+                          {config.text.login.errorUserUnauthorized}
+                        </Text>
+                      )}
+
+                      {/* if anything other than a 401: outputs the returned error message (or a generic error message instead) */}
+                      {!loginUnauthorized && (
+                        <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
+                          {(loginError?.message || config.text.login.errorUserGeneric) + '\n'}
+                          {config.text.login.nextStepAfterError}
+                        </Text>
+                      )}
+                    </View>
+                  )}
                 </View>
               </View>
             }
@@ -123,6 +145,10 @@ localStyle = StyleSheet.create({
     marginLeft: config.appConfig.scaleUiFkt(70),
     marginRight: config.appConfig.scaleUiFkt(70),
     ...config.theme.fonts.subHeader1,
+  },
+
+  loginErrorText: {
+    color: config.theme.colors.alert
   },
 
   qrScannerContainer: {

--- a/src/screens/login/loginScreen.jsx
+++ b/src/screens/login/loginScreen.jsx
@@ -98,13 +98,12 @@ class LoginScreen extends Component {
                         </Text>
                       )}
 
-                      {/* if anything other than a 401: outputs the returned error message (or a generic error message instead) */}
+                      {/* if anything other than a 401: outputs the returned error message (or a generic error message instead) followed by another instructional string*/}
                       {!loginUnauthorized && (
                         <View>
                           <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
-                            {(loginError?.message || config.text.login.errorUserGeneric)}
-                          </Text>
-                          <Text style={{...localStyle.infoText, ...localStyle.loginErrorText}}>
+                            {loginError?.message ?? config.text.login.errorUserGeneric}
+                            {'\n'}
                             {config.text.login.nextStepAfterError}
                           </Text>
                         </View>


### PR DESCRIPTION
This PR addresses #61 and adds a really rudimentary form of error handling to the login-screen.
Should an error occur during authentication, an error message will be displayed at lower half of the screen in the project-defined alert color.

The content of the displayed message is determined as follows:
1. Should the error be of type 401, a custom message defined in the file `textConfig.js` is being displayed.
2. Should it be another type of error with a valid error-message, then that message is being displayed with an accompanying string defined by the file `textConfig.js` (for example something like "try again later").
3. If no valid error-message was received a generic message defined in the file `textConfig.js` is being displayed. 

<img width="350" alt="Screenshot 2021-09-20 at 10 25 54" src="https://user-images.githubusercontent.com/4212661/133974636-935ae41b-dfd2-4547-a52e-b0721257e28c.png">


