### PR TITLE
Fix for the proper removal of a set subjectId 

### DIFF
--- a/src/screens/login/loginActions.js
+++ b/src/screens/login/loginActions.js
@@ -82,13 +82,19 @@ export const sendCredentials =
           // reactivates the camera
           if (camera) camera.reactivate();
           // persists the error
-          dispatch(sendCredentialsFail(err));
+          dispatch(sendCredentialsFail({
+            loginError: err.error ?? textConf.login.errorUserGeneric,
+            loginUnauthorized: err.error?.response?.status === 401
+          }));
         });
     } else {
       // reactivates the camera
       if (camera) camera.reactivate();
       // persists a generic error
-      dispatch(sendCredentialsFail(textConf.login.noSubjectId));
+      dispatch(sendCredentialsFail({
+        loginError: textConf.login.noSubjectId,
+        loginUnauthorized: false
+      }));
     }
   };
 

--- a/src/screens/login/loginReducer.js
+++ b/src/screens/login/loginReducer.js
@@ -1,3 +1,4 @@
+
 // (C) Copyright IBM Deutschland GmbH 2021.  All rights reserved.
 
 /***********************************************************************************************
@@ -49,15 +50,14 @@ const actionHandlers = {
    * @param  {object} state redux state
    * @param  {object} values values to be set
    */
-  SEND_CREDENTIALS_FAIL: (state, values) => ({
-    ...state,
-    loginError: values.error,
-    loading: false,
-    loginUnauthorized:
-      values.error.response &&
-      values.error.response.status &&
-      values.error.response.status === 401,
-  }),
+  SEND_CREDENTIALS_FAIL: (state, values) => (
+    {
+      ...state,
+      ...values,
+      subjectId: null,
+      loading: false
+    }
+  ),
 
   /**
    * just updates the subjectId
@@ -91,7 +91,7 @@ const actionHandlers = {
    */
   LOGOUT: (state) => ({
     ...state,
-    subjectId: "",
+    subjectId: null,
     session: null,
     loginError: null,
     loggedIn: false,


### PR DESCRIPTION
This PR addresses issue #63.
It allows for the proper removal of a set subjectId from the login-state. This in turn prohibits the app from trying to remove the subjectId persisted through the encrypted storage (which is the cause for the thrown exception).