### PR TITLE
fix comparison of codings

### DIFF
--- a/src/components/modal/questionnaireModal.jsx
+++ b/src/components/modal/questionnaireModal.jsx
@@ -360,16 +360,6 @@ class QuestionnaireModal extends Component {
     return returnValue;
   };
 
-  /**
-   * compares two different valueCoding Objects
-   */
-  compareCoding = (val1, val2) => {
-    if (val1 && val2)
-      return val1.system === val2.system && val1.code === val2.code;
-
-    return false;
-  };
-
   // creating questionnaire items
   /*-----------------------------------------------------------------------------------*/
 
@@ -473,7 +463,7 @@ class QuestionnaireModal extends Component {
                           this.removeOpenAnswer(item);
                         }}
                         checked={
-                          this.compareCoding(
+                          exportService.codingEquals(
                             exportService.getCorrectlyFormattedAnswer(
                               questionnaireItemMap[item.linkId]
                             ),

--- a/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
+++ b/src/services/questionnaireAnalyzer/questionnaireAnalyzer.js
@@ -414,10 +414,23 @@ const checkCompletionStateOfMultipleItems = (items, props) => {
  * Compares two Codings for equality - assuming display is always set and always unique (as it should in all real cases)
  * @param coding1 the first coding to compare
  * @param coding2 the second coding to compare
- * @return {boolean} true if both display's are equal - false otherwise
+ * @return {boolean} true if _either_:
+ *    a) coding1 and coding2 have both a valid system *and* a valid coding which both are equal _or_
+ *    b) coding1 and coding 2 only have display values which are equal
  */
-const codingEquals = (coding1, coding2) => coding1.display === coding2.display;
-
+const codingEquals = (coding1, coding2) => {
+  if (coding1 && coding2)
+    return (
+      (coding1.system &&
+        coding1.code &&
+        coding2.system &&
+        coding2.code &&
+        coding1.system === coding2.system &&
+        coding1.code === coding2.code) ||
+      coding1.display === coding2.display
+    );
+  return false;
+};
 /**
  * checks the dependencies of a single item (presented through its "enableWhen" property).
  * this basically tells us if the items needs to be rendered or if its answer should have
@@ -785,6 +798,7 @@ export
 ***********************************************************************************************/
 
 export default {
+  codingEquals,
   getFormattedDate,
   createResponseJSON,
   calculatePageProgress,


### PR DESCRIPTION
if neither system nor code are supplied, the display values are compared and checked for equality.
This is necessary but _not_ sufficient for #32.

Also, there were two methods which compared codings and those are now combined to one which resides in the questionnaireAnalyzer.