### PR TITLE
encode questionnaireId

### DIFF
--- a/src/services/rest/loggedInClient.js
+++ b/src/services/rest/loggedInClient.js
@@ -212,7 +212,9 @@ const getBaseQuestionnaire = async (questionnaireId, langCode) =>
   kioskMode.active
     ? kioskMode.getBaseQuestionnaire(langCode)
     : axios.get(
-        `${config.appConfig.endpoints.getQuestionnaire}${questionnaireId}/${langCode}`,
+        `${config.appConfig.endpoints.getQuestionnaire}${encodeURIComponent(
+          questionnaireId,
+        )}/${langCode}`,
         {
           headers: {
             Authorization: createAuthorizationToken(),


### PR DESCRIPTION
the questionnaireID is URI encoded as it is a URL and therefore contains special characters that would otherwise lead to the questionnaire not being found.

Fixes #78.